### PR TITLE
chore/remove preverification gas

### DIFF
--- a/chain-abstraction/add-guardian.ts
+++ b/chain-abstraction/add-guardian.ts
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
 
     console.log("[3/6] Paymaster commit on both chains...")
 
-    const commitOverrides = { preVerificationGasPercentageMultiplier: 20, context: { signingPhase: "commit" as const } };
+    const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
             smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,

--- a/chain-abstraction/add-owner-eip712-signed.ts
+++ b/chain-abstraction/add-owner-eip712-signed.ts
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
 
     console.log("[2/6] Paymaster commit on both chains...")
 
-    const commitOverrides = { preVerificationGasPercentageMultiplier: 20, context: { signingPhase: "commit" as const } };
+    const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
             smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,

--- a/chain-abstraction/add-owner-passkey.ts
+++ b/chain-abstraction/add-owner-passkey.ts
@@ -108,7 +108,7 @@ async function main(): Promise<void> {
 
     console.log("[3/8] Paymaster commit on both chains...")
 
-    const commitOverrides = { preVerificationGasPercentageMultiplier: 20, context: { signingPhase: "commit" as const } };
+    const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
             smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,

--- a/chain-abstraction/add-owner.ts
+++ b/chain-abstraction/add-owner.ts
@@ -68,7 +68,7 @@ async function main(): Promise<void> {
 
     console.log("[2/5] Paymaster commit on both chains...")
 
-    const commitOverrides = { preVerificationGasPercentageMultiplier: 20, context: { signingPhase: "commit" as const } };
+    const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
             smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,


### PR DESCRIPTION
- **fix preVerificationGasPercentageMultiplier in chain abstraction examples**
- **remove preverification gas multiplier from chain abstarction (bundler relaxed its rules)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted gas fee calculation configuration in paymaster sponsorship operations across chain abstraction modules by removing an explicit multiplier override, ensuring more accurate gas estimation during transaction sponsorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->