### PR TITLE
add per-chain sponsorship policy IDs to chain abstraction examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ NODE_URL1=https://ethereum-sepolia-rpc.publicnode.com
 NODE_URL2=https://sepolia.optimism.io
 CHAIN_ID1=11155111
 CHAIN_ID2=11155420
+SPONSORSHIP_POLICY_ID1=<your-policy-id-chain1>
+SPONSORSHIP_POLICY_ID2=<your-policy-id-chain2>
 ```
 
 Run any example:
@@ -83,6 +85,8 @@ npx ts-node <folder>/<script>.ts
 | `PRIVATE_KEY` | Yes | Your EOA private key (becomes account owner) |
 | `SPONSORSHIP_POLICY_ID` | Optional | For custom sponsorship policies |
 | `TOKEN_ADDRESS` | For ERC-20 gas | Token to pay gas with |
+| `SPONSORSHIP_POLICY_ID1` | For chain-abstraction | Sponsorship policy for chain 1 |
+| `SPONSORSHIP_POLICY_ID2` | For chain-abstraction | Sponsorship policy for chain 2 |
 | `BUNDLER_URL1` | For chain-abstraction | ERC-4337 bundler endpoint |
 | `BUNDLER_URL2` | For chain-abstraction | ERC-4337 bundler endpoint |
 | `NODE_URL1` | For chain-abstraction | Chain 1 RPC endpoint |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ NODE_URL1=https://ethereum-sepolia-rpc.publicnode.com
 NODE_URL2=https://sepolia.optimism.io
 CHAIN_ID1=11155111
 CHAIN_ID2=11155420
-SPONSORSHIP_POLICY_ID1=<your-policy-id-chain1>
-SPONSORSHIP_POLICY_ID2=<your-policy-id-chain2>
+SPONSORSHIP_POLICY_ID1=
+SPONSORSHIP_POLICY_ID2=
 ```
 
 Run any example:

--- a/chain-abstraction/add-guardian.ts
+++ b/chain-abstraction/add-guardian.ts
@@ -25,7 +25,7 @@ import {
 } from "abstractionkit";
 
 async function main(): Promise<void> {
-    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2 } = loadMultiChainEnv()
+    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2, sponsorshipPolicyId1, sponsorshipPolicyId2 } = loadMultiChainEnv()
     const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
 
     // Generate guardian address (or use from env)
@@ -82,10 +82,10 @@ async function main(): Promise<void> {
     const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
         ),
     ])
     userOperation1 = commitOp1
@@ -110,10 +110,10 @@ async function main(): Promise<void> {
     const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
     const [[finalOp1], [finalOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner-eip712-signed.ts
+++ b/chain-abstraction/add-owner-eip712-signed.ts
@@ -27,7 +27,7 @@ import {
 } from "abstractionkit";
 
 async function main(): Promise<void> {
-    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2 } = loadMultiChainEnv()
+    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2, sponsorshipPolicyId1, sponsorshipPolicyId2 } = loadMultiChainEnv()
     const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
     const ownerAccount = privateKeyToAccount(ownerPrivateKey as `0x${string}`)
 
@@ -74,10 +74,10 @@ async function main(): Promise<void> {
     const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
         ),
     ])
     userOperation1 = commitOp1
@@ -130,10 +130,10 @@ async function main(): Promise<void> {
     const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
     const [[finalOp1], [finalOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner-passkey.ts
+++ b/chain-abstraction/add-owner-passkey.ts
@@ -36,7 +36,7 @@ import {
 } from '../passkeys/webauthn';
 
 async function main(): Promise<void> {
-    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2 } = loadMultiChainEnv()
+    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2, sponsorshipPolicyId1, sponsorshipPolicyId2 } = loadMultiChainEnv()
 
     console.log("=".repeat(60))
     console.log("ADD OWNER - PASSKEY (WEBAUTHN) SIGNED DEMO")
@@ -111,10 +111,10 @@ async function main(): Promise<void> {
     const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
         ),
     ])
     userOperation1 = commitOp1
@@ -177,10 +177,10 @@ async function main(): Promise<void> {
     const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
     const [[finalOp1], [finalOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner.ts
+++ b/chain-abstraction/add-owner.ts
@@ -22,7 +22,7 @@ import {
 } from "abstractionkit";
 
 async function main(): Promise<void> {
-    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2 } = loadMultiChainEnv()
+    const { chainId1, chainId2, bundlerUrl1, bundlerUrl2, nodeUrl1, nodeUrl2, paymasterUrl1, paymasterUrl2, sponsorshipPolicyId1, sponsorshipPolicyId2 } = loadMultiChainEnv()
     const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
 
     // Generate a new owner address to add
@@ -71,10 +71,10 @@ async function main(): Promise<void> {
     const commitOverrides = { context: { signingPhase: "commit" as const } };
     const [[commitOp1], [commitOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
         ),
     ])
     userOperation1 = commitOp1
@@ -99,10 +99,10 @@ async function main(): Promise<void> {
     const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
     const [[finalOp1], [finalOp2]] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, undefined, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, undefined, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
         ),
     ])
     userOperation1 = finalOp1

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -88,6 +88,7 @@ export function loadMultiChainEnv() {
         nodeUrl2: requireEnv('NODE_URL2'),
         paymasterUrl1: requireEnv('PAYMASTER_URL1'),
         paymasterUrl2: requireEnv('PAYMASTER_URL2'),
-        sponsorshipPolicyId: get('SPONSORSHIP_POLICY_ID') || undefined,
+        sponsorshipPolicyId1: get('SPONSORSHIP_POLICY_ID1') || undefined,
+        sponsorshipPolicyId2: get('SPONSORSHIP_POLICY_ID2') || undefined,
     }
 }


### PR DESCRIPTION
## Summary
- Add `SPONSORSHIP_POLICY_ID1` and `SPONSORSHIP_POLICY_ID2` env vars for per-chain sponsorship policies in chain abstraction examples
- Pass policy IDs to all `createSponsorPaymasterUserOperation` calls (commit and finalize phases) across all 4 chain abstraction examples
- Update `loadMultiChainEnv()` to return per-chain policy IDs instead of a single shared one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new chain-specific sponsorship policy configuration environment variables in the setup guide.

* **Features**
  * Extended multi-chain configuration to support separate sponsorship policy IDs per blockchain. Users can now configure distinct sponsorship policies for each chain independently, providing greater flexibility in managing multi-chain deployments compared to the previous single global configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->