### PR TITLE
Bump abstractionkit to 0.3.1 and add ERC-7677 examples

### DIFF
--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
 
   // 4. Add paymaster for gas sponsorship
   const paymaster = new CandidePaymaster(paymasterUrl);
-  [userOp] = await paymaster.createSponsorPaymasterUserOperation(userOp, bundlerUrl);
+  [userOp] = await paymaster.createSponsorPaymasterUserOperation(smartAccount, userOp, bundlerUrl);
 
   // 5. Sign
   userOp.signature = smartAccount.signUserOperation(userOp, [ownerPrivateKey], chainId);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,11 @@ npx ts-node <folder>/<script>.ts
 | Goal | Folder | Key File |
 |------|--------|----------|
 | Gasless transactions | `sponsor-gas/` | `sponsor-gas.ts` |
+| Gasless — any ERC-7677 provider | `erc7677/` | `sponsor-gas.ts` |
 | Passkey/biometric login | `passkeys/` | `index.ts` |
 | Multi-owner wallet | `multisig/` | `multisig.ts` |
 | Pay gas with ERC-20 | `pay-gas-in-erc20/` | `pay-gas-in-erc20.ts` |
+| Pay gas with ERC-20 — any ERC-7677 provider | `erc7677/` | `pay-gas-in-erc20.ts` |
 | Batch multiple txs | `batch-transactions/` | `batch-transactions.ts` |
 | Account recovery | `recovery/` | `recovery.ts` |
 | EIP-7702 delegation | `eip-7702/simple-account/` | `01-upgrade-eoa.ts` |
@@ -154,7 +156,7 @@ let userOp = await smartAccount.createUserOperation(
 
 // 4. (Optional) Add paymaster for sponsorship
 const paymaster = new CandidePaymaster(paymasterUrl);
-[userOp] = await paymaster.createSponsorPaymasterUserOperation(userOp, bundlerUrl);
+[userOp] = await paymaster.createSponsorPaymasterUserOperation(smartAccount, userOp, bundlerUrl);
 
 // 5. Sign
 userOp.signature = smartAccount.signUserOperation(userOp, [privateKey], chainId);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Signature doesn't match expected signer(s).
 All examples follow this structure:
 
 ```typescript
-import { SafeAccountV0_3_0 as SafeAccount, MetaTransaction } from "abstractionkit";
+import { SafeAccountV0_3_0 as SafeAccount, MetaTransaction, CandidePaymaster } from "abstractionkit";
 
 // 1. Initialize account
 let smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress]);

--- a/chain-abstraction/README.md
+++ b/chain-abstraction/README.md
@@ -157,11 +157,22 @@ const signature = await walletClient.signTypedData({
 });
 
 // Format single signature into per-UserOperation signatures.
-// Per-op overrides (e.g. isInit, safe4337ModuleAddress) live on each entry.
+// Each entry is { userOperation, chainId, overrides? }. The `overrides`
+// object carries per-op options — typically `isInit` (true when that
+// chain's account is not yet deployed) and optionally
+// `safe4337ModuleAddress` if you're not using the default module.
 const signatures = SafeAccount.formatSignaturesToUseroperationsSignatures(
     [
-        { userOperation: userOp1, chainId: chainId1 },
-        { userOperation: userOp2, chainId: chainId2 },
+        {
+            userOperation: userOp1,
+            chainId: chainId1,
+            overrides: { isInit: userOp1.nonce == 0n },
+        },
+        {
+            userOperation: userOp2,
+            chainId: chainId2,
+            overrides: { isInit: userOp2.nonce == 0n },
+        },
     ],
     [{ signer: ownerAddress, signature }]
 );

--- a/chain-abstraction/README.md
+++ b/chain-abstraction/README.md
@@ -156,9 +156,13 @@ const signature = await walletClient.signTypedData({
     message: eip712Data.messageValue
 });
 
-// Format single signature into per-UserOperation signatures
+// Format single signature into per-UserOperation signatures.
+// Per-op overrides (e.g. isInit, safe4337ModuleAddress) live on each entry.
 const signatures = SafeAccount.formatSignaturesToUseroperationsSignatures(
-    [{ userOperation: userOp1, chainId: chainId1 }, { userOperation: userOp2, chainId: chainId2 }],
+    [
+        { userOperation: userOp1, chainId: chainId1 },
+        { userOperation: userOp2, chainId: chainId2 },
+    ],
     [{ signer: ownerAddress, signature }]
 );
 ```

--- a/chain-abstraction/add-owner-eip712-signed.ts
+++ b/chain-abstraction/add-owner-eip712-signed.ts
@@ -117,7 +117,6 @@ async function main(): Promise<void> {
     const signatures = SafeAccount.formatSignaturesToUseroperationsSignatures(
         userOperationsToSign,
         [{ signer: ownerPublicAddress, signature }],
-        { safe4337ModuleAddress: eip712Data.domain.verifyingContract } as any,
     );
 
     console.log("  Formatted into", signatures.length, "UserOperation signatures")

--- a/chain-abstraction/add-owner-passkey.ts
+++ b/chain-abstraction/add-owner-passkey.ts
@@ -97,12 +97,17 @@ async function main(): Promise<void> {
 
     console.log("\n[2/8] Creating UserOperations for both chains...")
 
+    // expectedSigners tells the bundler gas estimator to build a realistic
+    // WebAuthn dummy signature using this passkey's pubkey coordinates.
+    // Without it, estimation under-counts verification gas for passkey signers.
+    const createOpOverrides = { expectedSigners: [webauthPublicKey] };
+
     let [userOperation1, userOperation2] = await Promise.all([
         smartAccount.createUserOperation(
-            [addOwnerTx], nodeUrl1, bundlerUrl1,
+            [addOwnerTx], nodeUrl1, bundlerUrl1, createOpOverrides,
         ),
         smartAccount.createUserOperation(
-            [addOwnerTx], nodeUrl2, bundlerUrl2,
+            [addOwnerTx], nodeUrl2, bundlerUrl2, createOpOverrides,
         ),
     ]);
 
@@ -121,8 +126,16 @@ async function main(): Promise<void> {
     userOperation2 = commitOp2
 
     const userOperationsToSign = [
-        { userOperation: userOperation1, chainId: chainId1 },
-        { userOperation: userOperation2, chainId: chainId2 }
+        {
+            userOperation: userOperation1,
+            chainId: chainId1,
+            overrides: { isInit: userOperation1.nonce == 0n },
+        },
+        {
+            userOperation: userOperation2,
+            chainId: chainId2,
+            overrides: { isInit: userOperation2.nonce == 0n },
+        },
     ];
 
     console.log("[4/8] Getting cross-chain EIP-712 hash for signing...")
@@ -164,7 +177,6 @@ async function main(): Promise<void> {
     const signatures = SafeAccount.formatSignaturesToUseroperationsSignatures(
         userOperationsToSign,
         [signerSignaturePair],
-        { isInit: userOperation1.nonce == 0n, safe4337ModuleAddress: SafeAccount.DEFAULT_SAFE_4337_MODULE_ADDRESS } as any,
     );
 
     console.log("  Single passkey signature formatted into", signatures.length, "UserOperation signatures")

--- a/eip-7702/README.md
+++ b/eip-7702/README.md
@@ -101,7 +101,7 @@ const paymaster = new CandidePaymaster(paymasterUrl);
 ### Sponsorship using Policies
 
 ```ts
-const [sponsorUserOp, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation( userOperation, bundlerUrl)
+const [sponsorUserOp, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(smartAccount, userOperation, bundlerUrl)
 
 userOperation = sponsorUserOp
 ```

--- a/erc7677/pay-gas-in-erc20.ts
+++ b/erc7677/pay-gas-in-erc20.ts
@@ -1,0 +1,82 @@
+import { loadEnv, getOrCreateOwner, requireEnv } from '../utils/env'
+import {
+    SafeAccountV0_3_0 as SafeAccount,
+    MetaTransaction,
+    Erc7677Paymaster,
+    getFunctionSelector,
+    createCallData,
+} from "abstractionkit";
+
+/**
+ * Pay gas in an ERC-20 token via any ERC-7677 paymaster.
+ *
+ * Passing `{ token }` in the context triggers the token-gas flow. For
+ * Candide and Pimlico, the provider is auto-detected from the paymaster
+ * URL, the exchange rate is fetched from the provider's RPC, and the
+ * ERC-20 approval is prepended to callData automatically.
+ *
+ * Requirement: fund the smart account with enough of the ERC-20 token
+ * BEFORE running this script, otherwise the paymaster rejects the op.
+ *
+ * See ../pay-gas-in-erc20/pay-gas-in-erc20.ts for the Candide-specific
+ * variant (token-cost estimation via `calculateUserOperationErc20TokenMaxGasCost`).
+ */
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl } = loadEnv()
+    const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
+    const tokenAddress = requireEnv('TOKEN_ADDRESS')
+
+    // 1. Initialize a new smart account.
+    //    (Fund it with the ERC-20 token before running — see header.)
+    const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress])
+    console.log("Smart account:", smartAccount.accountAddress)
+
+    // 2. Build a transaction (mint an NFT).
+    const nftContractAddress = "0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336"
+    const transaction: MetaTransaction = {
+        to: nftContractAddress,
+        value: 0n,
+        data: createCallData(
+            getFunctionSelector("mint(address)"),
+            ["address"],
+            [smartAccount.accountAddress],
+        ),
+    }
+
+    // 3. Create the UserOperation.
+    let userOperation = await smartAccount.createUserOperation(
+        [transaction],
+        nodeUrl,
+        bundlerUrl,
+    )
+
+    // 4. Pay gas in ERC-20 via the ERC-7677 paymaster.
+    const paymaster = new Erc7677Paymaster(paymasterUrl)
+    userOperation = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOperation,
+        bundlerUrl,
+        { token: tokenAddress },
+    )
+
+    // 5. Sign and send.
+    userOperation.signature = smartAccount.signUserOperation(
+        userOperation,
+        [ownerPrivateKey],
+        chainId,
+    )
+    const response = await smartAccount.sendUserOperation(userOperation, bundlerUrl)
+    console.log("UserOperation sent. Waiting to be included...")
+
+    const receipt = await response.included()
+    if (receipt == null) {
+        console.log("Receipt not found (timeout)")
+    } else if (receipt.success) {
+        console.log("NFT minted. Tx hash:", receipt.receipt.transactionHash)
+    } else {
+        console.log("UserOperation execution failed")
+    }
+}
+
+main()

--- a/erc7677/sponsor-gas.ts
+++ b/erc7677/sponsor-gas.ts
@@ -47,14 +47,18 @@ async function main(): Promise<void> {
     )
 
     // 4. Sponsor the UserOperation via the ERC-7677 paymaster.
-    //    Note: `sponsorshipPolicyId` is used by Candide and Pimlico.
-    //    Other providers (e.g. Alchemy) expect `policyId` instead.
+    //    Candide and Pimlico read `sponsorshipPolicyId`; Alchemy reads
+    //    `policyId`. We send both so this example is portable across
+    //    providers — unknown keys are ignored.
     const paymaster = new Erc7677Paymaster(paymasterUrl)
+    const context = sponsorshipPolicyId
+        ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId }
+        : {}
     userOperation = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
-        sponsorshipPolicyId ? { sponsorshipPolicyId } : {},
+        context,
     )
 
     const cost = calculateUserOperationMaxGasCost(userOperation)

--- a/erc7677/sponsor-gas.ts
+++ b/erc7677/sponsor-gas.ts
@@ -1,0 +1,82 @@
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import {
+    SafeAccountV0_3_0 as SafeAccount,
+    MetaTransaction,
+    Erc7677Paymaster,
+    calculateUserOperationMaxGasCost,
+    getFunctionSelector,
+    createCallData,
+} from "abstractionkit";
+
+/**
+ * Sponsored (gasless) UserOperation via any ERC-7677 paymaster.
+ *
+ * Works with any provider that implements ERC-7677 — Candide, Pimlico,
+ * Alchemy, and others. The provider is auto-detected from the paymaster
+ * URL, and provider-specific optimizations are used when available.
+ *
+ * See ../sponsor-gas/sponsor-gas.ts for the Candide-specific variant
+ * (SponsorMetadata, richer helpers).
+ */
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
+
+    // 1. Initialize a new smart account.
+    const smartAccount = SafeAccount.initializeNewAccount([ownerPublicAddress])
+    console.log("Smart account:", smartAccount.accountAddress)
+
+    // 2. Build a transaction (mint an NFT).
+    const nftContractAddress = "0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336"
+    const transaction: MetaTransaction = {
+        to: nftContractAddress,
+        value: 0n,
+        data: createCallData(
+            getFunctionSelector("mint(address)"),
+            ["address"],
+            [smartAccount.accountAddress],
+        ),
+    }
+
+    // 3. Create the UserOperation.
+    let userOperation = await smartAccount.createUserOperation(
+        [transaction],
+        nodeUrl,
+        bundlerUrl,
+    )
+
+    // 4. Sponsor the UserOperation via the ERC-7677 paymaster.
+    //    Note: `sponsorshipPolicyId` is used by Candide and Pimlico.
+    //    Other providers (e.g. Alchemy) expect `policyId` instead.
+    const paymaster = new Erc7677Paymaster(paymasterUrl)
+    userOperation = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOperation,
+        bundlerUrl,
+        sponsorshipPolicyId ? { sponsorshipPolicyId } : {},
+    )
+
+    const cost = calculateUserOperationMaxGasCost(userOperation)
+    console.log("This UserOperation may cost up to:", cost, "wei (sponsored by the paymaster)")
+
+    // 5. Sign and send.
+    userOperation.signature = smartAccount.signUserOperation(
+        userOperation,
+        [ownerPrivateKey],
+        chainId,
+    )
+    const response = await smartAccount.sendUserOperation(userOperation, bundlerUrl)
+    console.log("UserOperation sent. Waiting to be included...")
+
+    const receipt = await response.included()
+    if (receipt == null) {
+        console.log("Receipt not found (timeout)")
+    } else if (receipt.success) {
+        console.log("NFT minted. Tx hash:", receipt.receipt.transactionHash)
+    } else {
+        console.log("UserOperation execution failed")
+    }
+}
+
+main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "abstractionkit": "^0.3.0",
+        "abstractionkit": "^0.3.1",
         "cbor": "^10.0.12",
         "dotenv": "^16.5.0",
         "viem": "^2.44.4"
@@ -19,11 +19,21 @@
         "typescript": "^5.8.3"
       }
     },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
+    "../abstractionkit": {
+      "version": "0.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "ethers": "^6.13.2"
+      },
+      "devDependencies": {
+        "dotenv": "^16.4.5",
+        "jest": "^29.7.0",
+        "tsdown": "^0.21.6",
+        "typescript": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -50,30 +60,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -165,15 +151,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/abitype": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
@@ -196,22 +173,8 @@
       }
     },
     "node_modules/abstractionkit": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.0.tgz",
-      "integrity": "sha512-Qt8OXtQFTfmAWwWCapAxHh74o3U/nnGap8Rv/dvdDfYgCLNS31yZOYOrHKiWC3zu43BbWxXDW7XOiQ/1KreoTw==",
-      "license": "MIT",
-      "dependencies": {
-        "ethers": "^6.13.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
+      "resolved": "../abstractionkit",
+      "link": true
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
@@ -328,34 +291,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -744,12 +679,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -763,12 +692,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/viem": {
       "version": "2.44.4",
@@ -967,6 +890,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "abstractionkit": "^0.3.0",
+    "abstractionkit": "^0.3.1",
     "cbor": "^10.0.12",
     "dotenv": "^16.5.0",
     "viem": "^2.44.4"

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -45,7 +45,8 @@ export function requireEnv(key: string): string {
  */
 export function getOrCreateOwner(): { publicAddress: string; privateKey: string } {
     const address = process.env.PUBLIC_ADDRESS
-    const key = process.env.PRIVATE_KEY
+    const rawKey = process.env.PRIVATE_KEY
+    const key = rawKey && !rawKey.startsWith('0x') ? `0x${rawKey}` : rawKey
 
     if (address && key) return { publicAddress: address, privateKey: key }
 


### PR DESCRIPTION
## Summary
- Upgrades `abstractionkit` to `^0.3.1` and updates docs + chain-abstraction examples to the new API signatures (`createSponsorPaymasterUserOperation(smartAccount, ...)`, per-op overrides on `userOperationsToSign` entries).
- Adds a new `erc7677/` folder with portable `sponsor-gas.ts` and `pay-gas-in-erc20.ts` reference examples that work against any ERC-7677 provider (Candide, Pimlico, Alchemy, ...). The Candide-specific variants under `sponsor-gas/` and `pay-gas-in-erc20/` stay as-is.
- Small DX fix: `utils/env.ts` now auto-prepends `0x` to `PRIVATE_KEY` when missing.

## Test plan
- [x] `npm install` resolves `abstractionkit@0.3.1`
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Run `erc7677/sponsor-gas.ts` end-to-end against Arbitrum Sepolia (public endpoints) and confirm a sponsored mint
- [ ] Run `erc7677/pay-gas-in-erc20.ts` end-to-end with a funded smart account and confirm a token-paid mint
- [ ] Smoke-test one chain-abstraction example (`add-owner-passkey.ts`) to confirm the override refactor still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new ERC-7677 example scripts demonstrating gasless transactions and paying gas with ERC-20 tokens.
  * Updated paymaster sponsorship function signature to accept account context parameter for improved flexibility.

* **Documentation**
  * Updated documentation with new ERC-7677 examples and clarified code patterns across sponsorship flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->