### PR TITLE
docs: on-chain identifier example for tracking active users and userOps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ npx ts-node <folder>/<script>.ts
 | EIP-712 signed UserOp | `eip-712-signing/` | `eip-712-signing.ts` |
 | Nested Safe accounts | `nested-safe-accounts/` | `nested-safe-accounts.ts` |
 | Spending limits | `spend-permission/` | `spend-permission.ts` |
+| Track active users / userOps on-chain | `onchain-identifier/` | `onchain-identifier.ts` |
 | Calibur 7702 upgrade EOA + gas sponsorship | `eip-7702/calibur-account/` | `01-upgrade-eoa.ts` |
 | Calibur 7702 passkeys | `eip-7702/calibur-account/` | `02-passkeys.ts` |
 | Calibur 7702 key management | `eip-7702/calibur-account/` | `03-manage-keys.ts` |

--- a/onchain-identifier/README.md
+++ b/onchain-identifier/README.md
@@ -41,10 +41,6 @@ retroactively tagged.
 
 Each content field is `keccak256(value)` truncated to its byte width.
 
-> The Safe docs page currently says "50 bytes in length" — that's a docs bug.
-> The field widths sum to 32, the SDK produces 32, and the example tx they
-> link to carries 32. [Canonical docs page.](https://docs.safe.global/sdk/onchain-tracking)
-
 ## Indexer pattern
 
 ### Exact: decode `UserOperationEvent`

--- a/onchain-identifier/README.md
+++ b/onchain-identifier/README.md
@@ -1,0 +1,91 @@
+# On-chain tracking
+
+Attribute active users and userOperations to your project by tagging each
+userOp's `callData` with a 32-byte marker. Your indexer filters on the marker —
+no extra infrastructure, no off-chain correlation.
+
+## How it works
+
+Pass `onChainIdentifierParams` when you initialize the Safe account. The SDK
+appends the marker to every userOp's `callData`:
+
+```ts
+const smartAccount = SafeAccount.initializeNewAccount([owner], {
+  onChainIdentifierParams: {
+    project:     'YourProject',      // required — the thing you key analytics off
+    platform:    'Web',              // optional — 'Web' | 'Mobile' | 'Safe App' | 'Widget'
+    tool:        'abstractionkit',   // optional — which SDK
+    toolVersion: '0.3.2',            // optional — SDK version
+  },
+})
+
+console.log(smartAccount.onChainIdentifier) // 0x5afe00...
+```
+
+Already-deployed account? Pass the same params to the constructor:
+
+```ts
+const smartAccount = new SafeAccount(accountAddress, { onChainIdentifierParams: { project: 'YourProject' } })
+```
+
+Works the same — future userOps are tagged; historical userOps are not
+retroactively tagged.
+
+## Marker layout (32 bytes)
+
+```
+5afe │ 00 │ project(20) │ platform(3) │ tool(3) │ toolVersion(3)
+└─prefix  │
+   version
+```
+
+Each content field is `keccak256(value)` truncated to its byte width.
+
+> The Safe docs page currently says "50 bytes in length" — that's a docs bug.
+> The field widths sum to 32, the SDK produces 32, and the example tx they
+> link to carries 32. [Canonical docs page.](https://docs.safe.global/sdk/onchain-tracking)
+
+## Indexer pattern
+
+### Exact: decode `UserOperationEvent`
+
+The EntryPoint emits a `UserOperationEvent` log for every included userOp.
+Decode it, pull the userOp's `callData`, and check the suffix. **This is the
+one to use — it's per-userOp and the marker sits exactly at the tail.**
+
+```ts
+const endsWithId = userOp.callData.toLowerCase().endsWith(identifier.toLowerCase())
+```
+
+Aggregate:
+
+- Unique `sender` values → active users
+- Total matching events → userOp volume
+- Group by the identifier's trailing hashes → split by platform/tool/version
+
+### Fuzzy: substring match on the bundler tx input
+
+The bundler wraps the userOp in `EntryPoint.handleOps(ops[], beneficiary)`.
+The marker ends up *inside* the tx `input`, not at the tail — a trailing
+beneficiary address sits after it. Use substring (not suffix) match:
+
+```ts
+const tagged = tx.input.toLowerCase().includes(identifier.toLowerCase())
+```
+
+Good enough for quick dashboards, but batches of multiple userOps in one
+`handleOps` call appear as one match. Prefer the event-based approach.
+
+## Run the example
+
+```bash
+npx ts-node onchain-identifier/onchain-identifier.ts
+```
+
+Uses the public Arbitrum Sepolia endpoints from
+[`CLAUDE.md`](../CLAUDE.md) — no signup needed.
+
+## Register your project
+
+Submit your identifier so Safe can attribute on-chain activity to you:
+https://forms.gle/NYkorYebc6Fz1fMW6

--- a/onchain-identifier/README.md
+++ b/onchain-identifier/README.md
@@ -33,7 +33,7 @@ retroactively tagged.
 
 ## Marker layout (32 bytes)
 
-```
+```text
 5afe │ 00 │ project(20) │ platform(3) │ tool(3) │ toolVersion(3)
 └─prefix  │
    version

--- a/onchain-identifier/onchain-identifier.ts
+++ b/onchain-identifier/onchain-identifier.ts
@@ -112,4 +112,7 @@ async function main(): Promise<void> {
     )
 }
 
-main()
+main().catch((err: unknown) => {
+    console.error('FAILED:', err instanceof Error ? err.message : String(err))
+    process.exit(1)
+})

--- a/onchain-identifier/onchain-identifier.ts
+++ b/onchain-identifier/onchain-identifier.ts
@@ -1,0 +1,115 @@
+/**
+ * On-chain tracking — attribute active users and userOperations to your project.
+ *
+ * Pass `onChainIdentifierParams` when initializing the Safe account. The SDK
+ * then appends a 32-byte marker to every userOperation's `callData`. Your
+ * indexer can filter the EntryPoint's `UserOperationEvent` (or the bundler's
+ * `handleOps` tx input) for that marker to attribute traffic to your project.
+ *
+ * Marker layout (32 bytes):
+ *
+ *     5afe │ 00 │ project(20) │ platform(3) │ tool(3) │ toolVersion(3)
+ *     └─prefix  │
+ *        version
+ *
+ * Each variable-content field is `keccak256(value)` truncated to its width.
+ *
+ * Register your identifier with the Safe team: https://forms.gle/NYkorYebc6Fz1fMW6
+ *
+ * Run:
+ *     npx ts-node onchain-identifier/onchain-identifier.ts
+ */
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import {
+    SafeAccountV0_3_0 as SafeAccount,
+    MetaTransaction,
+    CandidePaymaster,
+    getFunctionSelector,
+    createCallData,
+    sendJsonRpcRequest,
+} from 'abstractionkit'
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress: owner, privateKey: ownerKey } = getOrCreateOwner()
+
+    // ─── 1. Tag the account with your project identifier ──────────────────
+    // Only `project` is required. `platform`, `tool`, `toolVersion` refine
+    // attribution (Web vs Mobile, which SDK, which version). Use the same
+    // values everywhere — your analytics key off this exact string.
+    const smartAccount = SafeAccount.initializeNewAccount([owner], {
+        onChainIdentifierParams: {
+            project: 'AbstractionKit Examples',
+            platform: 'Web',
+            tool: 'abstractionkit',
+            toolVersion: '0.3.2',
+        },
+    })
+
+    // For already-deployed accounts, pass the same `onChainIdentifierParams`
+    // to the constructor; new userOps will carry the marker from that point on.
+    // Historical userOps are not retroactively tagged.
+
+    const identifier = smartAccount.onChainIdentifier as string
+    console.log('Sender     :', smartAccount.accountAddress)
+    console.log('Identifier : 0x' + identifier)
+
+    // ─── 2. Build a sample userOperation (mint an NFT) ────────────────────
+    const nft = '0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336'
+    const mint: MetaTransaction = {
+        to: nft,
+        value: 0n,
+        data: createCallData(
+            getFunctionSelector('mint(address)'),
+            ['address'],
+            [smartAccount.accountAddress],
+        ),
+    }
+
+    let userOp = await smartAccount.createUserOperation([mint], nodeUrl, bundlerUrl)
+
+    // The marker sits at the tail of `userOp.callData`. This is the field
+    // your indexer should match — it's exact, per-userOp, 32 bytes.
+    const tagged = userOp.callData.toLowerCase().endsWith(identifier.toLowerCase())
+    console.log('Tag in userOp.callData :', tagged)
+
+    // ─── 3. Sponsor, sign, send ───────────────────────────────────────────
+    const paymaster = new CandidePaymaster(paymasterUrl)
+    ;[userOp] = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, userOp, bundlerUrl, sponsorshipPolicyId,
+    )
+    userOp.signature = smartAccount.signUserOperation(userOp, [ownerKey], chainId)
+
+    console.log('Sending userOp ...')
+    const response = await smartAccount.sendUserOperation(userOp, bundlerUrl)
+    const receipt = await response.included()
+
+    if (!receipt || !receipt.success) {
+        console.log('UserOp did not land.')
+        return
+    }
+    console.log('Included   :', receipt.receipt.transactionHash)
+
+    // ─── 4. Verify the marker on-chain ────────────────────────────────────
+    // The bundler wraps your userOp in `EntryPoint.handleOps(ops[], beneficiary)`.
+    // The marker lives *inside* the tx input (inside the encoded userOp
+    // callData), not at the tail — so use a substring check for tx input.
+    // For exact attribution, decode `UserOperationEvent` logs instead.
+    const tx = (await sendJsonRpcRequest(
+        nodeUrl, 'eth_getTransactionByHash', [receipt.receipt.transactionHash],
+    )) as { input: string } | null
+    if (tx) {
+        console.log('Tag in tx.input        :', tx.input.toLowerCase().includes(identifier.toLowerCase()))
+    }
+
+    // ─── 5. How to aggregate in your indexer ──────────────────────────────
+    // - Subscribe to `UserOperationEvent` on the EntryPoint contract.
+    // - For each event, check whether the userOp's `callData` ends with your
+    //   32-byte identifier.
+    // - Unique `sender` values = active users. Total matches = userOp volume.
+    console.log(
+        '\nAttribute userOps by matching this 32-byte suffix on userOp.callData:\n  0x' + identifier,
+    )
+}
+
+main()


### PR DESCRIPTION
## Summary
- New `onchain-identifier/` example showing how to attribute userOperations to a project via `SafeAccountV0_3_0`'s `onChainIdentifierParams` (32-byte marker appended to every userOp's `callData`).
- README with copy-pasteable init snippet (new + existing accounts), marker layout, both indexer patterns (exact via `UserOperationEvent`, fuzzy via `handleOps` tx input substring), and a note on the Safe docs prose mislabeling the marker as "50 bytes" (actual: 32).
- Adds a row to the goals table in `AGENTS.md` / `CLAUDE.md`.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx ts-node onchain-identifier/onchain-identifier.ts` runs end-to-end on Arbitrum Sepolia with the public Candide paymaster
- [x] Verified marker sits at the tail of `userOp.callData` and appears as a substring of the included tx `input`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for on-chain user-operation tracking: configuration, identifier layout, and two indexing approaches (exact vs fuzzy)
  * Added an end-to-end example script demonstrating initializing tracking, creating/sending a user operation, and verifying identifier presence
  * Updated the examples index with a new on-chain tracking use case and registration instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->