### PR TITLE
Bump abstractionkit to 0.3.4 and migrate paymaster API

### DIFF
--- a/batch-transactions/batch-transactions.ts
+++ b/batch-transactions/batch-transactions.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
     )
 
     const paymaster = new CandidePaymaster(paymasterUrl)
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId)
     userOperation = paymasterUserOperation;
 

--- a/chain-abstraction/add-guardian.ts
+++ b/chain-abstraction/add-guardian.ts
@@ -19,6 +19,7 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import {
     SafeMultiChainSigAccountV1 as SafeAccount,
     CandidePaymaster,
+    type CandidePaymasterContext,
     SocialRecoveryModule,
     SocialRecoveryModuleGracePeriodSelector,
     UserOperationV9,
@@ -79,13 +80,13 @@ async function main(): Promise<void> {
 
     console.log("[3/6] Paymaster commit on both chains...")
 
-    const commitOverrides = { context: { signingPhase: "commit" as const } };
-    const [[commitOp1], [commitOp2]] = await Promise.all([
+    const commitContext: CandidePaymasterContext = { signingPhase: "commit" };
+    const [{ userOperation: commitOp1 }, { userOperation: commitOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitContext,
         ),
     ])
     userOperation1 = commitOp1
@@ -107,13 +108,13 @@ async function main(): Promise<void> {
 
     console.log("[5/6] Paymaster finalize on both chains...")
 
-    const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
-    const [[finalOp1], [finalOp2]] = await Promise.all([
+    const finalizeContext: CandidePaymasterContext = { signingPhase: "finalize" };
+    const [{ userOperation: finalOp1 }, { userOperation: finalOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeContext,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner-eip712-signed.ts
+++ b/chain-abstraction/add-owner-eip712-signed.ts
@@ -23,6 +23,7 @@ import { sepolia } from 'viem/chains'
 import {
     SafeMultiChainSigAccountV1 as SafeAccount,
     CandidePaymaster,
+    type CandidePaymasterContext,
     UserOperationV9,
 } from "abstractionkit";
 
@@ -71,13 +72,13 @@ async function main(): Promise<void> {
 
     console.log("[2/6] Paymaster commit on both chains...")
 
-    const commitOverrides = { context: { signingPhase: "commit" as const } };
-    const [[commitOp1], [commitOp2]] = await Promise.all([
+    const commitContext: CandidePaymasterContext = { signingPhase: "commit" };
+    const [{ userOperation: commitOp1 }, { userOperation: commitOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitContext,
         ),
     ])
     userOperation1 = commitOp1
@@ -126,13 +127,13 @@ async function main(): Promise<void> {
 
     console.log("[5/6] Paymaster finalize on both chains...")
 
-    const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
-    const [[finalOp1], [finalOp2]] = await Promise.all([
+    const finalizeContext: CandidePaymasterContext = { signingPhase: "finalize" };
+    const [{ userOperation: finalOp1 }, { userOperation: finalOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeContext,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner-passkey.ts
+++ b/chain-abstraction/add-owner-passkey.ts
@@ -21,6 +21,7 @@ import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import {
     SafeMultiChainSigAccountV1 as SafeAccount,
     CandidePaymaster,
+    type CandidePaymasterContext,
     WebauthnPublicKey,
     WebauthnSignatureData,
     SignerSignaturePair,
@@ -113,13 +114,13 @@ async function main(): Promise<void> {
 
     console.log("[3/8] Paymaster commit on both chains...")
 
-    const commitOverrides = { context: { signingPhase: "commit" as const } };
-    const [[commitOp1], [commitOp2]] = await Promise.all([
+    const commitContext: CandidePaymasterContext = { signingPhase: "commit" };
+    const [{ userOperation: commitOp1 }, { userOperation: commitOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitContext,
         ),
     ])
     userOperation1 = commitOp1
@@ -186,13 +187,13 @@ async function main(): Promise<void> {
 
     console.log("[7/8] Paymaster finalize on both chains...")
 
-    const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
-    const [[finalOp1], [finalOp2]] = await Promise.all([
+    const finalizeContext: CandidePaymasterContext = { signingPhase: "finalize" };
+    const [{ userOperation: finalOp1 }, { userOperation: finalOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeContext,
         ),
     ])
     userOperation1 = finalOp1

--- a/chain-abstraction/add-owner-with-external-signer.ts
+++ b/chain-abstraction/add-owner-with-external-signer.ts
@@ -21,6 +21,7 @@
 
 import {
     CandidePaymaster,
+    type CandidePaymasterContext,
     SafeMultiChainSigAccountV1 as SafeAccount,
     fromViem,
 } from 'abstractionkit'
@@ -57,8 +58,8 @@ async function main(): Promise<void> {
 
     const paymaster1 = new CandidePaymaster(paymasterUrl1)
     const paymaster2 = new CandidePaymaster(paymasterUrl2)
-    const commit = { context: { signingPhase: 'commit' as const } }
-    const finalize = { context: { signingPhase: 'finalize' as const } }
+    const commit: CandidePaymasterContext = { signingPhase: 'commit' }
+    const finalize: CandidePaymasterContext = { signingPhase: 'finalize' }
 
     // 4. Assemble a UserOperation on each chain.
     let [op1, op2] = await Promise.all([
@@ -75,7 +76,7 @@ async function main(): Promise<void> {
             smartAccount, op2, bundlerUrl2, sponsorshipPolicyId2, commit,
         ),
     ])
-    ;[op1, op2] = [committed[0][0], committed[1][0]]
+    ;[op1, op2] = [committed[0].userOperation, committed[1].userOperation]
 
     // 6. ONE signing call, N signatures out.
     const signatures = await smartAccount.signUserOperationsWithSigners(
@@ -98,7 +99,7 @@ async function main(): Promise<void> {
             smartAccount, op2, bundlerUrl2, sponsorshipPolicyId2, finalize,
         ),
     ])
-    ;[op1, op2] = [finalized[0][0], finalized[1][0]]
+    ;[op1, op2] = [finalized[0].userOperation, finalized[1].userOperation]
 
     // 8. Submit to each bundler concurrently and wait for inclusion.
     const [resp1, resp2] = await Promise.all([

--- a/chain-abstraction/add-owner.ts
+++ b/chain-abstraction/add-owner.ts
@@ -18,6 +18,7 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import {
     SafeMultiChainSigAccountV1 as SafeAccount,
     CandidePaymaster,
+    type CandidePaymasterContext,
     UserOperationV9,
 } from "abstractionkit";
 
@@ -68,13 +69,13 @@ async function main(): Promise<void> {
 
     console.log("[2/5] Paymaster commit on both chains...")
 
-    const commitOverrides = { context: { signingPhase: "commit" as const } };
-    const [[commitOp1], [commitOp2]] = await Promise.all([
+    const commitContext: CandidePaymasterContext = { signingPhase: "commit" };
+    const [{ userOperation: commitOp1 }, { userOperation: commitOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, commitContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, commitContext,
         ),
     ])
     userOperation1 = commitOp1
@@ -96,13 +97,13 @@ async function main(): Promise<void> {
 
     console.log("[4/5] Paymaster finalize on both chains...")
 
-    const finalizeOverrides = { context: { signingPhase: "finalize" as const } };
-    const [[finalOp1], [finalOp2]] = await Promise.all([
+    const finalizeContext: CandidePaymasterContext = { signingPhase: "finalize" };
+    const [{ userOperation: finalOp1 }, { userOperation: finalOp2 }] = await Promise.all([
         paymaster1.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeOverrides,
+            smartAccount, userOperation1, bundlerUrl1, sponsorshipPolicyId1, finalizeContext,
         ),
         paymaster2.createSponsorPaymasterUserOperation(
-            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeOverrides,
+            smartAccount, userOperation2, bundlerUrl2, sponsorshipPolicyId2, finalizeContext,
         ),
     ])
     userOperation1 = finalOp1

--- a/eip-712-signing/eip-712-signing.ts
+++ b/eip-712-signing/eip-712-signing.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
 
     // Sponsor with paymaster
     const paymaster = new CandidePaymaster(paymasterUrl)
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId)
     userOperation = paymasterUserOperation;
 

--- a/eip-7702/calibur-account/01-upgrade-eoa.ts
+++ b/eip-7702/calibur-account/01-upgrade-eoa.ts
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
     // ──────────────────────────────────────────────────────────────────────
     // In EP v0.8, paymaster data is included in the UserOperation hash,
     // so it must be set before signing.
-    let [sponsoredUserOperation] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId,
     )
     userOperation = sponsoredUserOperation

--- a/eip-7702/calibur-account/02-passkeys.ts
+++ b/eip-7702/calibur-account/02-passkeys.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
         )
     }
 
-    let [sponsoredRegisterOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredRegisterOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, registerOp, bundlerUrl, sponsorshipPolicyId,
     )
     registerOp = sponsoredRegisterOp
@@ -197,7 +197,7 @@ async function main(): Promise<void> {
     )
 
     // Sponsor gas before signing (EP v0.8 includes paymaster data in hash)
-    let [sponsoredUserOperation] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId,
     )
     userOperation = sponsoredUserOperation

--- a/eip-7702/calibur-account/03-manage-keys.ts
+++ b/eip-7702/calibur-account/03-manage-keys.ts
@@ -97,7 +97,7 @@ async function main(): Promise<void> {
     let registerOp = await smartAccount.createUserOperation(
         registerTxs, nodeUrl, bundlerUrl,
     )
-    let [sponsoredRegisterOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredRegisterOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, registerOp, bundlerUrl, sponsorshipPolicyId,
     )
     registerOp = sponsoredRegisterOp
@@ -142,7 +142,7 @@ async function main(): Promise<void> {
         [{ to: nftContractAddress, value: 0n, data: mintCallData }],
         nodeUrl, bundlerUrl,
     )
-    let [sponsoredSecondaryOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredSecondaryOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, secondaryOp, bundlerUrl, sponsorshipPolicyId,
     )
     secondaryOp = sponsoredSecondaryOp
@@ -181,7 +181,7 @@ async function main(): Promise<void> {
     let updateOp = await smartAccount.createUserOperation(
         [updateTx], nodeUrl, bundlerUrl,
     )
-    let [sponsoredUpdateOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredUpdateOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, updateOp, bundlerUrl, sponsorshipPolicyId,
     )
     updateOp = sponsoredUpdateOp
@@ -215,7 +215,7 @@ async function main(): Promise<void> {
     let revokeOp = await smartAccount.createUserOperation(
         [revokeTx], nodeUrl, bundlerUrl,
     )
-    let [sponsoredRevokeOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredRevokeOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, revokeOp, bundlerUrl, sponsorshipPolicyId,
     )
     revokeOp = sponsoredRevokeOp

--- a/eip-7702/calibur-account/04-external-signer.ts
+++ b/eip-7702/calibur-account/04-external-signer.ts
@@ -73,10 +73,11 @@ async function main(): Promise<void> {
 
     // 6. Sponsor gas via an ERC-7677 paymaster.
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 7. Sign the UserOperation hash via the ExternalSigner.
     userOp.signature = await smartAccount.signUserOperationWithSigner(

--- a/eip-7702/simple-account/01-upgrade-eoa.ts
+++ b/eip-7702/simple-account/01-upgrade-eoa.ts
@@ -63,7 +63,7 @@ async function main(): Promise<void> {
     // Step 4: Sponsor gas with paymaster
     // ──────────────────────────────────────────────────────────────────────
     const paymaster = new CandidePaymaster(paymasterUrl)
-    let [paymasterUserOperation] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId)
     userOperation = paymasterUserOperation
 

--- a/eip-7702/simple-account/02-upgrade-eoa-erc20-gas.ts
+++ b/eip-7702/simple-account/02-upgrade-eoa-erc20-gas.ts
@@ -75,18 +75,18 @@ async function main(): Promise<void> {
         return
     }
 
-    userOperation = await paymaster.createTokenPaymasterUserOperation(
+    // v0.3.3+: createTokenPaymasterUserOperation returns the maximum
+    // token cost (`tokenQuote.tokenCost`) and exchange rate alongside
+    // the UserOperation, so a separate `calculateUserOperationErc20TokenMaxGasCost`
+    // round-trip is no longer needed for cost display.
+    const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
         smartAccount,
         userOperation,
         tokenSelected.address,
         bundlerUrl,
     )
-
-    const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
-        smartAccount,
-        userOperation,
-        tokenSelected.address,
-    )
+    userOperation = tokenOp
+    const cost = tokenQuote?.tokenCost ?? 0n
     console.log("Estimated gas cost: " + cost + " wei in " + tokenSelected.symbol)
     console.log("Sender account: " + userOperation.sender)
 

--- a/eip-7702/simple-account/03-upgrade-eoa-ep-v09.ts
+++ b/eip-7702/simple-account/03-upgrade-eoa-ep-v09.ts
@@ -56,12 +56,13 @@ async function main(): Promise<void> {
     // ──────────────────────────────────────────────────────────────────────
     console.log("Paymaster commit: estimating gas...")
 
-    let [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: commitOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
         sponsorshipPolicyId,
-        { entrypoint: smartAccount.entrypointAddress, context: { signingPhase: "commit" as const } },
+        { signingPhase: "commit" },
+        { entrypoint: smartAccount.entrypointAddress },
     )
     userOperation = commitOp
 
@@ -77,12 +78,13 @@ async function main(): Promise<void> {
     // ──────────────────────────────────────────────────────────────────────
     console.log("Paymaster finalize: getting final paymasterData...")
 
-    let [finalizedOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: finalizedOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
         sponsorshipPolicyId,
-        { entrypoint: smartAccount.entrypointAddress, context: { signingPhase: "finalize" as const } },
+        { signingPhase: "finalize" },
+        { entrypoint: smartAccount.entrypointAddress },
     )
     userOperation = finalizedOp
 

--- a/eip-7702/simple-account/05-external-signer.ts
+++ b/eip-7702/simple-account/05-external-signer.ts
@@ -73,10 +73,11 @@ async function main(): Promise<void> {
 
     // 6. Sponsor gas via an ERC-7677 paymaster.
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 7. Sign the UserOperation hash via the ExternalSigner.
     userOp.signature = await smartAccount.signUserOperationWithSigner(

--- a/eip-7702/simple-account/06-external-signer-v09.ts
+++ b/eip-7702/simple-account/06-external-signer-v09.ts
@@ -77,9 +77,9 @@ async function main(): Promise<void> {
     }
 
     // 6. Paymaster COMMIT: stub data + gas estimation.
-    let [commitOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: commitOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl, sponsorshipPolicyId,
-        { context: { signingPhase: 'commit' as const } },
+        { signingPhase: 'commit' },
     )
     userOp = commitOp
 
@@ -90,9 +90,9 @@ async function main(): Promise<void> {
     )
 
     // 8. Paymaster FINALIZE: paymaster signature now covers the signed op.
-    let [finalizedOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: finalizedOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl, sponsorshipPolicyId,
-        { context: { signingPhase: 'finalize' as const } },
+        { signingPhase: 'finalize' },
     )
     userOp = finalizedOp
 

--- a/erc7677/pay-gas-in-erc20.ts
+++ b/erc7677/pay-gas-in-erc20.ts
@@ -53,12 +53,17 @@ async function main(): Promise<void> {
 
     // 4. Pay gas in ERC-20 via the ERC-7677 paymaster.
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOperation = await paymaster.createPaymasterUserOperation(
+    const { userOperation: tokenOp, tokenQuote } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
         { token: tokenAddress },
     )
+    userOperation = tokenOp
+
+    if (tokenQuote) {
+        console.log("Max token cost:", tokenQuote.tokenCost, "(exchange rate:", tokenQuote.exchangeRate, ")")
+    }
 
     // 5. Sign and send.
     userOperation.signature = smartAccount.signUserOperation(

--- a/erc7677/sponsor-gas.ts
+++ b/erc7677/sponsor-gas.ts
@@ -54,12 +54,13 @@ async function main(): Promise<void> {
     const context = sponsorshipPolicyId
         ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId }
         : {}
-    userOperation = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount,
         userOperation,
         bundlerUrl,
         context,
     )
+    userOperation = sponsoredOp
 
     const cost = calculateUserOperationMaxGasCost(userOperation)
     console.log("This UserOperation may cost up to:", cost, "wei (sponsored by the paymaster)")

--- a/multisig/multisig.ts
+++ b/multisig/multisig.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    const [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     userOperation = paymasterUserOperation;
 

--- a/nested-safe-accounts/nested-safe-accounts.ts
+++ b/nested-safe-accounts/nested-safe-accounts.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     )
     const paymaster = new CandidePaymaster(paymasterUrl);
 
-    const [paymasterSubAccount1UserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterSubAccount1UserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         subAccount1, subAccount1DeployMainAccountUserOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     subAccount1DeployMainAccountUserOperation = paymasterSubAccount1UserOperation;
 
@@ -137,7 +137,7 @@ async function main(): Promise<void> {
         }
     )
 
-    let [paymasterUserOperation1, _sponsorMetadata1] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation1 } = await paymaster.createSponsorPaymasterUserOperation(
         mainAccount, mainAccountUserOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     mainAccountUserOperation = paymasterUserOperation1;
 
@@ -168,7 +168,7 @@ async function main(): Promise<void> {
         nodeUrl,
         bundlerUrl,
     )
-    const [paymasterSubAccount1UserOperation11, _sponsorMetadata11] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterSubAccount1UserOperation11 } = await paymaster.createSponsorPaymasterUserOperation(
         subAccount1, subAccount1UserOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     subAccount1UserOperation = paymasterSubAccount1UserOperation11;
 
@@ -182,7 +182,7 @@ async function main(): Promise<void> {
         nodeUrl,
         bundlerUrl,
     )
-    const [paymasterSubAccount2UserOperation, _sponsorMetadata2] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterSubAccount2UserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         subAccount2, subAccount2UserOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     subAccount2UserOperation = paymasterSubAccount2UserOperation;
 

--- a/onchain-identifier/onchain-identifier.ts
+++ b/onchain-identifier/onchain-identifier.ts
@@ -75,9 +75,10 @@ async function main(): Promise<void> {
 
     // ─── 3. Sponsor, sign, send ───────────────────────────────────────────
     const paymaster = new CandidePaymaster(paymasterUrl)
-    ;[userOp] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl, sponsorshipPolicyId,
     )
+    userOp = sponsoredOp
     userOp.signature = smartAccount.signUserOperation(userOp, [ownerKey], chainId)
 
     console.log('Sending userOp ...')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "abstractionkit": "^0.3.2",
+        "abstractionkit": "^0.3.4",
         "cbor": "^10.0.12",
         "dotenv": "^16.5.0",
         "viem": "^2.44.4"
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/abstractionkit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.2.tgz",
-      "integrity": "sha512-Ay2Sxd7bpX/hzjV5QhrUjxppLFombSPjamqxuRwwE7WMMGAJLhmWI88FCS5cHYSsLbXxtemsxr9DWSReegbf/A==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.4.tgz",
+      "integrity": "sha512-NqCwkaKZj6Bg8C7U+xo2t82f7rq149zn2v1MOkNLLO/KB5GC0qhTIwmo7I1L7QZTt86dLxId4R6IPw85cfrgjw==",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "abstractionkit": "^0.3.2",
+    "abstractionkit": "^0.3.4",
     "cbor": "^10.0.12",
     "dotenv": "^16.5.0",
     "viem": "^2.44.4"

--- a/passkeys/index.ts
+++ b/passkeys/index.ts
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
 
     // Request paymaster sponsorship
     let paymaster: CandidePaymaster = new CandidePaymaster(paymasterUrl)
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
       smartAccount,
       userOperation,
       bundlerUrl,

--- a/passkeys/passkeys-v0.2.1.ts
+++ b/passkeys/passkeys-v0.2.1.ts
@@ -15,7 +15,6 @@
  * In a real browser application, use the native navigator.credentials API.
  */
 
-import * as dotenv from 'dotenv'
 import { hexToBytes, keccak256, toBytes, numberToBytes } from 'viem'
 import {
   SafeAccountV0_3_0 as SafeAccount,
@@ -28,6 +27,7 @@ import {
   SignerSignaturePair,
 } from "abstractionkit";
 
+import { loadEnv } from '../utils/env'
 import {
   UserVerificationRequirement,
   WebAuthnCredentials,
@@ -56,22 +56,7 @@ const eip7212WebAuthnContractVerifier = "0xA86e0054C51E4894D88762a017ECc5E5235f5
 const webAuthnSignerProxyCreationCode = "0x610100346100ad57601f6101b538819003918201601f19168301916001600160401b038311848410176100b2578084926080946040528339810103126100ad578051906001600160a01b03821682036100ad5760208101516040820151606090920151926001600160b01b03841684036100ad5760805260a05260c05260e05260405160ec90816100c98239608051816082015260a05181604d015260c051816027015260e0518160010152f35b600080fd5b634e487b7160e01b600052604160045260246000fdfe7f000000000000000000000000000000000000000000000000000000000000000060b63601527f000000000000000000000000000000000000000000000000000000000000000060a03601527f000000000000000000000000000000000000000000000000000000000000000036608001523660006080376000806056360160807f00000000000000000000000000000000000000000000000000000000000000005af43d600060803e60b1573d6080fd5b3d6080f3fea26469706673582212201660515548d15702d720bbc046b457ca85e941a4559ab9f9518488e4c82e5ee964736f6c634300081a0033"
 
 async function main(): Promise<void> {
-  // Load environment variables
-  dotenv.config()
-
-  // Validate required environment variables
-  const requiredEnvVars = ['CHAIN_ID', 'BUNDLER_URL', 'NODE_URL', 'PAYMASTER_URL'];
-  for (const varName of requiredEnvVars) {
-    if (!process.env[varName]) {
-      throw new Error(`Missing required environment variable: ${varName}`);
-    }
-  }
-
-  const chainId = BigInt(process.env.CHAIN_ID as string)
-  const bundlerUrl = process.env.BUNDLER_URL as string
-  const nodeUrl = process.env.NODE_URL as string
-  const paymasterUrl = process.env.PAYMASTER_URL as string;
-  const sponsorshipPolicyId = process.env.SPONSORSHIP_POLICY_ID as string;
+  const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
 
   // Simulated WebAuthn navigator for demonstration
   // In a real browser, you would use: window.navigator.credentials

--- a/passkeys/passkeys-v0.2.1.ts
+++ b/passkeys/passkeys-v0.2.1.ts
@@ -166,7 +166,7 @@ async function main(): Promise<void> {
 
     // Request paymaster sponsorship
     let paymaster: CandidePaymaster = new CandidePaymaster(paymasterUrl)
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
       smartAccount,
       userOperation,
       bundlerUrl,

--- a/pay-gas-in-erc20/pay-gas-in-erc20.ts
+++ b/pay-gas-in-erc20/pay-gas-in-erc20.ts
@@ -79,17 +79,18 @@ async function main(): Promise<void> {
     console.log("Visit our Discord to get some CTT token for testing");
 
     if (tokenSelected) {
-        userOperation = await paymaster.createTokenPaymasterUserOperation(
+        // v0.3.3+: createTokenPaymasterUserOperation returns the maximum
+        // token cost (`tokenQuote.tokenCost`) and exchange rate alongside
+        // the UserOperation, so a separate `calculateUserOperationErc20TokenMaxGasCost`
+        // round-trip is no longer needed for cost display.
+        const { userOperation: tokenOp, tokenQuote } = await paymaster.createTokenPaymasterUserOperation(
             smartAccount,
             userOperation,
             tokenSelected.address,
             bundlerUrl,
         )
-        const cost = await paymaster.calculateUserOperationErc20TokenMaxGasCost(
-            smartAccount,
-            userOperation,
-            tokenSelected.address,
-        )
+        userOperation = tokenOp
+        const cost = tokenQuote?.tokenCost ?? 0n
         console.log("This useroperation may cost upto : " + cost + " wei in CTT token")
         console.log(
             "Please fund the sender account : " +

--- a/recovery/recovery.ts
+++ b/recovery/recovery.ts
@@ -51,7 +51,7 @@ async function main(): Promise<void> {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     userOperation = paymasterUserOperation;
 

--- a/signer/customSigner.ts
+++ b/signer/customSigner.ts
@@ -68,10 +68,11 @@ async function main(): Promise<void> {
 
     // 5. Sponsor gas via an ERC-7677 paymaster (provider-agnostic).
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 6. Sign with the custom ExternalSigner.
     userOp.signature = await smartAccount.signUserOperationWithSigners(

--- a/signer/fromEthersWallet.ts
+++ b/signer/fromEthersWallet.ts
@@ -49,10 +49,11 @@ async function main(): Promise<void> {
 
     // 5. Sponsor gas via an ERC-7677 paymaster (provider-agnostic).
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 6. Sign with the ExternalSigner.
     userOp.signature = await smartAccount.signUserOperationWithSigners(

--- a/signer/fromViem.ts
+++ b/signer/fromViem.ts
@@ -46,10 +46,11 @@ async function main(): Promise<void> {
 
     // 5. Sponsor gas via an ERC-7677 paymaster (provider-agnostic).
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 6. Sign with the ExternalSigner.
     userOp.signature = await smartAccount.signUserOperationWithSigners(

--- a/signer/fromViemWalletClient.ts
+++ b/signer/fromViemWalletClient.ts
@@ -60,10 +60,11 @@ async function main(): Promise<void> {
 
     // 5. Sponsor gas via an ERC-7677 paymaster (provider-agnostic).
     const paymaster = new Erc7677Paymaster(paymasterUrl)
-    userOp = await paymaster.createPaymasterUserOperation(
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
         smartAccount, userOp, bundlerUrl,
         sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
     )
+    userOp = sponsoredOp
 
     // 6. Sign with the ExternalSigner. Safe negotiates and uses
     //    signTypedData (the only capability this adapter exposes).

--- a/spend-permission/spend-permission.ts
+++ b/spend-permission/spend-permission.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
 
     const paymaster = new CandidePaymaster(paymasterUrl);
 
-    let [sponsoredSetAllowanceUserOp, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredSetAllowanceUserOp } = await paymaster.createSponsorPaymasterUserOperation(
         sourceSafeAccount, setAllowanceUserOp, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     setAllowanceUserOp = sponsoredSetAllowanceUserOp;
 
@@ -115,7 +115,7 @@ async function main(): Promise<void> {
 
     let allowanceTransferUserOp = await delegateSafeAccount.createUserOperation([allowanceTransferMetaTransaction], nodeUrl, bundlerUrl);
 
-    let [sponsoredAllowanceTransferUserOp, _sponsorMetaData2] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: sponsoredAllowanceTransferUserOp } = await paymaster.createSponsorPaymasterUserOperation(
         delegateSafeAccount, allowanceTransferUserOp, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     allowanceTransferUserOp = sponsoredAllowanceTransferUserOp;
 

--- a/sponsor-gas/sponsor-gas.ts
+++ b/sponsor-gas/sponsor-gas.ts
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
+    const { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
         smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId) // sponsorshipPolicyId will have no effect if empty
     userOperation = paymasterUserOperation;
 


### PR DESCRIPTION
## Summary

- Bumps `abstractionkit` from `^0.3.2` to `^0.3.4`.
- Migrates every paymaster call site to the new return shape introduced in 0.3.3 (`createSponsorPaymasterUserOperation` → `{ userOperation, sponsorMetadata? }`; `createTokenPaymasterUserOperation` / `Erc7677Paymaster.createPaymasterUserOperation` → `{ userOperation, tokenQuote? }`).
- Hoists `CandidePaymasterContext` out of `overrides` into the dedicated 2nd-to-last argument on `createSponsorPaymasterUserOperation`.
- ERC-20 token examples now read max gas cost from `tokenQuote.tokenCost` instead of a separate `calculateUserOperationErc20TokenMaxGasCost` round-trip.
- Drive-by: `passkeys/passkeys-v0.2.1.ts` switched to the shared `loadEnv()` helper (so it picks up the built-in Arbitrum Sepolia defaults and stops requiring every var explicitly in `.env`).

## Commits

- `404e90b` chain-abstraction paymaster migration (typed context + result object)
- `f564c9e` repo-wide bump + paymaster migration on the remaining 26 examples
- `940de79` `passkeys-v0.2.1` env helper fix

## Test plan

- [x] `npm run build` (tsc) passes
- [x] End-to-end testnet runs on Arbitrum Sepolia — 20 / 20 sponsored examples pass (sponsor-gas, batch-transactions, recovery, eip-712-signing, multisig, nested-safe-accounts, onchain-identifier, erc7677/sponsor-gas, all 4 `signer/*`, `passkeys/index`, `passkeys/passkeys-v0.2.1`, all 5 `chain-abstraction/*`, `eip-7702/simple-account/04-revoke-delegation`)
- [ ] EIP-7702 examples (8 in `simple-account/` and `calibur-account/`) currently revert with `AA23` against the public Arbitrum Sepolia bundler. Same failure mode reproduces with both auto-generated and fixed EOAs (EOA verified `0x` code on-chain — not stuck on a stale delegation), and the bump did not touch any signing/validation path. **Tracked separately** — likely a bundler/contract-side issue, not part of this migration.
- [ ] ERC-20 token paymaster examples (`pay-gas-in-erc20/`, `erc7677/pay-gas-in-erc20.ts`, `eip-7702/simple-account/02-upgrade-eoa-erc20-gas.ts`) skipped — require a token-funded signer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated paymaster API integration across all examples to use structured object destructuring for sponsored user operations, improving code clarity and type safety.
  * Simplified ERC-20 gas payment flows by leveraging token cost data directly from paymaster responses, eliminating redundant API calls.
  * Standardized context handling for multi-phase paymaster sponsorship flows.

* **Chores**
  * Updated `abstractionkit` dependency to version `0.3.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->