### PR TITLE
docs(eip-7702): add typed-data builder example for Simple7702

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ npx ts-node <folder>/<script>.ts
 | EIP-7702 pay gas in ERC-20 | `eip-7702/simple-account/` | `02-upgrade-eoa-erc20-gas.ts` |
 | EIP-7702 EP v0.9 | `eip-7702/simple-account/` | `03-upgrade-eoa-ep-v09.ts` |
 | EIP-7702 revoke delegation | `eip-7702/simple-account/` | `04-revoke-delegation.ts` |
+| EIP-7702 typed-data builder (drive signTypedData yourself) | `eip-7702/simple-account/` | `07-typed-data-builder.ts` |
 | Debug with Tenderly | `simulate-with-tenderly/` | `simulate-with-tenderly.ts` |
 | Multichain-chain add owner | `chain-abstraction/` | `add-owner.ts` |
 | Multichain add guardian | `chain-abstraction/` | `add-guardian.ts` |

--- a/eip-7702/README.md
+++ b/eip-7702/README.md
@@ -12,7 +12,8 @@ eip-7702/
 │   ├── 03-upgrade-eoa-ep-v09.ts     # Upgrade EOA using EntryPoint v0.9
 │   ├── 04-revoke-delegation.ts      # Revoke EIP-7702 delegation
 │   ├── 05-external-signer.ts        # Upgrade EOA with the v0.3.2 ExternalSigner API
-│   └── 06-external-signer-v09.ts    # Same, EntryPoint v0.9 (two-phase paymaster)
+│   ├── 06-external-signer-v09.ts    # Same, EntryPoint v0.9 (two-phase paymaster)
+│   └── 07-typed-data-builder.ts     # Drive signTypedData yourself via getUserOperationEip712TypedData
 └── calibur-account/      # Calibur7702Account examples (passkeys, key management)
     ├── 01-upgrade-eoa.ts
     ├── 02-passkeys.ts

--- a/eip-7702/simple-account/07-typed-data-builder.ts
+++ b/eip-7702/simple-account/07-typed-data-builder.ts
@@ -1,0 +1,131 @@
+/**
+ * Drive `signTypedData` yourself using `getUserOperationEip712TypedData` —
+ * the lower-level path for integrators who already have a
+ * `signTypedData(domain, types, message)` primitive and don't want to
+ * wrap it in an ExternalSigner.
+ *
+ * Account class : Simple7702Account
+ * Signing API   : account.getUserOperationEip712TypedData(op, chainId)
+ *                 + your own signTypedData
+ * Paymaster     : Erc7677Paymaster (sponsored)
+ *
+ * When to reach for this instead of 05-external-signer.ts:
+ *  - You're building an SDK that exposes `signTypedData(domain, types,
+ *    message)` to its callers, and want to feed it the UserOperation's
+ *    typed data directly.
+ *  - You already have a typed-data signing function (a browser wallet
+ *    via WalletConnect/wagmi, an MPC service, an HSM, etc.) and would
+ *    rather call it directly than wrap it in an ExternalSigner adapter.
+ *  - You want to inspect / log / customize the {domain, types, message}
+ *    payload before it goes to the wallet UI.
+ *
+ * Why this works: EntryPoint v0.8 / v0.9's userOpHash IS the EIP-712
+ * digest of `PackedUserOperation` under the EntryPoint's domain. So a
+ * signTypedData result over those fields validates against the same
+ * userOpHash as a raw ECDSA signature over the hash. The two paths are
+ * interchangeable; the choice is purely about which signing primitive
+ * you already have.
+ *
+ * This example uses ethers' `Wallet.signTypedData` to demonstrate the
+ * API boundary — replace with viem, wagmi's `signTypedDataAsync`, an
+ * HSM RPC call, or any signTypedData implementation. The EIP-7702
+ * delegation authorization is a SEPARATE signature (see header in
+ * 05-external-signer.ts) and is signed via the callback overload of
+ * `createAndSignEip7702DelegationAuthorization` so the key never leaves
+ * ethers.
+ */
+
+import {
+    AbstractionKitError,
+    Erc7677Paymaster,
+    Simple7702Account,
+    createAndSignEip7702DelegationAuthorization,
+    createCallData,
+    getFunctionSelector,
+} from 'abstractionkit'
+import { Signature, Wallet } from 'ethers'
+
+import { getOrCreateOwner, loadEnv } from '../../utils/env'
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress, privateKey } = getOrCreateOwner()
+
+    // 1. Your `signTypedData` primitive. Stand-in for an SDK method, a
+    //    browser-wallet RPC call, an HSM, etc. — anything that exposes
+    //    signTypedData(domain, types, message).
+    const wallet = new Wallet(privateKey)
+    console.log('EOA     :', publicAddress)
+
+    // 2. Initialize the Simple7702 account.
+    const smartAccount = new Simple7702Account(publicAddress)
+
+    // 3. Build a MetaTransaction: mint an NFT to the EOA.
+    const nft = '0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336'
+    const mintData = createCallData(
+        getFunctionSelector('mint(address)'),
+        ['address'],
+        [publicAddress],
+    )
+
+    // 4. Assemble the UserOperation with an unsigned EIP-7702 authorization.
+    let userOp = await smartAccount.createUserOperation(
+        [{ to: nft, value: 0n, data: mintData }],
+        nodeUrl, bundlerUrl,
+        { eip7702Auth: { chainId } },
+    )
+
+    // 5. Sign the EIP-7702 delegation authorization. 
+    if (userOp.eip7702Auth) {
+        userOp.eip7702Auth = await createAndSignEip7702DelegationAuthorization(
+            BigInt(userOp.eip7702Auth.chainId),
+            userOp.eip7702Auth.address,
+            BigInt(userOp.eip7702Auth.nonce),
+            async (hash) => Signature.from(wallet.signingKey.sign(hash)).serialized,
+        )
+    }
+
+    // 6. Sponsor gas via an ERC-7677 paymaster. The paymaster fields are
+    //    written before signing; the typed data we sign in step 7 reflects
+    //    the final UserOperation shape.
+    const paymaster = new Erc7677Paymaster(paymasterUrl)
+    const { userOperation: sponsoredOp } = await paymaster.createPaymasterUserOperation(
+        smartAccount,
+        userOp,
+        bundlerUrl,
+        sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined,
+    )
+    userOp = sponsoredOp
+
+    // 7. Build the typed data and drive signTypedData yourself. The shape
+    //    is { domain, types, primaryType: 'PackedUserOperation', message }
+    //    — ready for any signTypedData implementation. ethers v6 infers
+    //    `EIP712Domain` automatically; viem / wallet RPCs accept the same
+    //    structure as-is.
+    const typedData = smartAccount.getUserOperationEip712TypedData(userOp, chainId)
+    userOp.signature = await wallet.signTypedData(
+        typedData.domain,
+        typedData.types,
+        typedData.message,
+    )
+
+    // 8. Send and wait for on-chain inclusion.
+    const response = await smartAccount.sendUserOperation(userOp, bundlerUrl)
+    console.log('UserOp  :', response.userOperationHash)
+    const receipt = await response.included()
+    if (!receipt) throw new Error('timeout waiting for inclusion')
+    console.log('Tx      :', receipt.receipt.transactionHash)
+    console.log('Success :', receipt.success)
+    if (!receipt.success) throw new Error('reverted on-chain')
+}
+
+main().catch((err: unknown) => {
+    if (err instanceof AbstractionKitError) {
+        console.error('FAILED :', err.code, '-', err.message)
+        if (err.context) console.error('Context:', err.context)
+        if (err.cause) console.error('Cause  :', err.cause)
+    } else {
+        console.error(err)
+    }
+    process.exit(1)
+})


### PR DESCRIPTION
## Summary

Adds `eip-7702/simple-account/07-typed-data-builder.ts` — the lower-level signing path for `Simple7702Account` (EntryPoint v0.8 / v0.9). Use this when you already have a `signTypedData(domain, types, message)` primitive (an SDK method, MPC service, HSM, browser-wallet RPC) and don't want to wrap it in an `ExternalSigner` adapter.

The userOpHash IS the EIP-712 digest of `PackedUserOperation` under the EntryPoint's domain, so the result validates against the same hash as the raw-hash path — the choice is purely about which signing primitive you already have.

- ethers `Wallet.signTypedData` is used as a stand-in for the API boundary; replace with viem, `wagmi.signTypedDataAsync`, an HSM RPC, etc.
- The EIP-7702 delegation authorization uses the callback overload of `createAndSignEip7702DelegationAuthorization` so the key never enters abstractionkit (matches the pattern from 05/06).
- Errors are surfaced via `AbstractionKitError` introspection (code + context + cause), consistent with the other typed-data-aware examples.

Also updates `eip-7702/README.md` and `AGENTS.md` to reference the new file.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` clean
- [x] End-to-end run against Arbitrum Sepolia — UserOp included on-chain, NFT minted, tx `0xedd11c1a94d54c47dbd1a70d3022f0ad969bb58160beabe9c8d299d81c5f591a`
- [ ] Reviewer-side: re-run with their own `.env` to confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new example demonstrating how to manually handle typed-data signing with EIP-7702 workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->