### PR TITLE
chore: bump abstractionkit to 0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "abstractionkit": "^0.3.4",
+        "abstractionkit": "^0.3.5",
         "cbor": "^10.0.12",
         "dotenv": "^16.5.0",
         "viem": "^2.44.4"
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/abstractionkit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.4.tgz",
-      "integrity": "sha512-NqCwkaKZj6Bg8C7U+xo2t82f7rq149zn2v1MOkNLLO/KB5GC0qhTIwmo7I1L7QZTt86dLxId4R6IPw85cfrgjw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.5.tgz",
+      "integrity": "sha512-Hjk8uYIxJx3/AsMn1BwEVXC4WBbVWen/tzVmAtfrWD2OGaJ5wDKV/X1Pgd5I4wGdRjyYjSBL9FBPOYeH2F38Iw==",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "abstractionkit": "^0.3.4",
+    "abstractionkit": "^0.3.5",
     "cbor": "^10.0.12",
     "dotenv": "^16.5.0",
     "viem": "^2.44.4"


### PR DESCRIPTION
## Summary
- Bump `abstractionkit` from `^0.3.4` to `^0.3.5` in `package.json`/`package-lock.json`.
- No API changes required — all examples compile unchanged.

## Test plan
- [x] `npm install` resolves `abstractionkit@0.3.5` from the registry
- [x] `npm run build` (tsc) passes across all examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency version to ensure compatibility with the latest package features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->