### PR TITLE
Update examples for abstractionkit 0.3.8

### DIFF
--- a/batch-transactions/batch-transactions-1-5-0.ts
+++ b/batch-transactions/batch-transactions-1-5-0.ts
@@ -1,21 +1,17 @@
-import * as dotenv from 'dotenv'
+import { loadEnv, getOrCreateOwner } from '../utils/env'
 
 import {
     SafeAccountV1_5_0_M_0_3_0,
     MetaTransaction,
     calculateUserOperationMaxGasCost,
+    CandidePaymaster,
     getFunctionSelector,
     createCallData,
 } from "abstractionkit";
 
-async function main(nonce:bigint): Promise<void> {
-    //get values from .env
-    dotenv.config()
-    const chainId = BigInt(process.env.CHAIN_ID as string)
-    const bundlerUrl = process.env.BUNDLER_URL as string
-    const nodeUrl = process.env.NODE_URL as string
-    const ownerPublicAddress = process.env.PUBLIC_ADDRESS as string
-    const ownerPrivateKey = process.env.PRIVATE_KEY as string
+async function main(nonce: bigint): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
 
     //initializeNewAccount only needed when the smart account
     //have not been deployed yet for its first useroperation.
@@ -72,11 +68,13 @@ async function main(nonce:bigint): Promise<void> {
     )
     const cost = calculateUserOperationMaxGasCost(userOperation)
     console.log("This useroperation may cost upto : " + cost + " wei")
-    console.log(
-        "Please fund the sender account : " +
-        userOperation.sender +
-        " with more than " + cost + " wei"
+
+    const paymaster = new CandidePaymaster(paymasterUrl)
+    const { userOperation: sponsoredUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId,
     )
+    userOperation = sponsoredUserOperation;
+    console.log("This example uses a Candide paymaster to sponsor the useroperation.")
 
     //Safe is a multisig that can have multiple owners/signers
     //signUserOperation will create a signature for the provided
@@ -111,7 +109,7 @@ async function main(nonce:bigint): Promise<void> {
     }
 }
 Promise.all([
-    main(0n),
+    main(BigInt(Date.now())),
     //main(1n),
     //main(2n)
 ])

--- a/chain-abstraction/add-guardian.ts
+++ b/chain-abstraction/add-guardian.ts
@@ -41,6 +41,7 @@ async function main(): Promise<void> {
     // Initialize SafeMultiChainSigAccountV1 for deterministic address across chains
     const smartAccount = SafeAccount.initializeNewAccount(
         [ownerPublicAddress],
+        { c2Nonce: BigInt(Date.now()) },
     )
 
     console.log("\nSafe Account (same on both chains):", smartAccount.accountAddress)
@@ -169,4 +170,7 @@ async function sendAndMonitorUserOperation(
     }
 }
 
-main().catch(console.error)
+main().catch((err: unknown) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/chain-abstraction/add-owner-with-external-signer.ts
+++ b/chain-abstraction/add-owner-with-external-signer.ts
@@ -4,12 +4,13 @@
  *
  * Account class : SafeMultiChainSigAccountV1 (EntryPoint v0.9)
  * Signing method: signUserOperationsWithSigners(items, [signer])
- * Signer adapter: fromViem
+ * Signer adapter: fromViemWalletClient
  * Paymaster     : CandidePaymaster (two-phase per chain: commit -> sign -> finalize)
  *
  * Key property: one call to signUserOperationsWithSigners produces one
- * signature per op from a single signing operation (Merkle root). The
- * user, HSM, or hardware wallet is prompted once for N chains.
+ * signature per op from a single EIP-712 signing operation over the
+ * Merkle root. Browser-wallet style signers that only expose
+ * `signTypedData` work on this multi-op path.
  *
  * Why CandidePaymaster here: EntryPoint v0.9 uses a two-phase paymaster
  * signing flow where the paymaster signature covers the owner signature.
@@ -23,8 +24,9 @@ import {
     CandidePaymaster,
     type CandidePaymasterContext,
     SafeMultiChainSigAccountV1 as SafeAccount,
-    fromViem,
+    fromViemWalletClient,
 } from 'abstractionkit'
+import { createWalletClient, http } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 
 import { getOrCreateOwner, loadMultiChainEnv } from '../utils/env'
@@ -39,11 +41,20 @@ async function main(): Promise<void> {
     } = loadMultiChainEnv()
     const { publicAddress, privateKey } = getOrCreateOwner()
 
-    // 1. Build the ExternalSigner and pick a new-owner address to add.
-    const signer = fromViem(privateKeyToAccount(privateKey as `0x${string}`))
+    // 1. Build a typed-data-only ExternalSigner and pick a new-owner
+    //    address to add. A real dApp would pass an injected/browser
+    //    WalletClient here; this local account keeps the example runnable
+    //    from Node while exercising the same `signTypedData`-only adapter.
+    const ownerAccount = privateKeyToAccount(privateKey as `0x${string}`)
+    const walletClient = createWalletClient({
+        account: ownerAccount,
+        transport: http(nodeUrl1),
+    })
+    const signer = fromViemWalletClient(walletClient)
     const newOwner = process.env.NEW_OWNER_ADDRESS
         ?? privateKeyToAccount(generatePrivateKey()).address
     console.log('Owner     :', publicAddress)
+    console.log('Signer    : signHash=false signTypedData=true')
     console.log('New owner :', newOwner)
     console.log('Chains    :', chainId1.toString(), '+', chainId2.toString())
 

--- a/eip-7702/README.md
+++ b/eip-7702/README.md
@@ -13,7 +13,7 @@ eip-7702/
 │   ├── 04-revoke-delegation.ts      # Revoke EIP-7702 delegation
 │   ├── 05-external-signer.ts        # Upgrade EOA with the v0.3.2 ExternalSigner API
 │   ├── 06-external-signer-v09.ts    # Same, EntryPoint v0.9 (two-phase paymaster)
-│   └── 07-typed-data-builder.ts     # Drive signTypedData yourself via getUserOperationEip712TypedData
+│   └── 07-typed-data-builder.ts     # Drive signTypedData yourself via getUserOperationEip712Data
 └── calibur-account/      # Calibur7702Account examples (passkeys, key management)
     ├── 01-upgrade-eoa.ts
     ├── 02-passkeys.ts

--- a/eip-7702/calibur-account/02-passkeys.ts
+++ b/eip-7702/calibur-account/02-passkeys.ts
@@ -29,9 +29,9 @@ import {
     Calibur7702Account,
     CandidePaymaster,
     createAndSignEip7702DelegationAuthorization,
-    getDelegatedAddress,
     getFunctionSelector,
     createCallData,
+    JsonRpcNode,
     WebAuthnSignatureData,
 } from "abstractionkit";
 
@@ -43,13 +43,14 @@ async function main(): Promise<void> {
 
     const smartAccount = new Calibur7702Account(publicAddress)
     const paymaster = new CandidePaymaster(paymasterUrl)
+    const node = JsonRpcNode.from(nodeUrl)
 
     // Check if the EOA is already delegated to the expected Calibur singleton.
     // isDelegated() returns true only if delegated to this account's delegateeAddress.
-    // getDelegatedAddress() returns the raw delegatee address for diagnostics.
+    // JsonRpcNode.getDelegatedAddress() returns the raw delegatee address for diagnostics.
     const alreadyDelegated = await smartAccount.isDelegatedToThisAccount(nodeUrl)
     if (!alreadyDelegated) {
-        const currentDelegatee = await getDelegatedAddress(publicAddress, nodeUrl);
+        const currentDelegatee = await node.getDelegatedAddress(publicAddress);
         if (currentDelegatee) {
             console.log("This EOA is delegated to a different singleton:", currentDelegatee)
             console.log("Expected:", smartAccount.delegateeAddress)

--- a/eip-7702/simple-account/07-typed-data-builder.ts
+++ b/eip-7702/simple-account/07-typed-data-builder.ts
@@ -1,11 +1,11 @@
 /**
- * Drive `signTypedData` yourself using `getUserOperationEip712TypedData` —
+ * Drive `signTypedData` yourself using `getUserOperationEip712Data` —
  * the lower-level path for integrators who already have a
  * `signTypedData(domain, types, message)` primitive and don't want to
  * wrap it in an ExternalSigner.
  *
  * Account class : Simple7702Account
- * Signing API   : account.getUserOperationEip712TypedData(op, chainId)
+ * Signing API   : Simple7702Account.getUserOperationEip712Data(op, chainId)
  *                 + your own signTypedData
  * Paymaster     : Erc7677Paymaster (sponsored)
  *
@@ -102,7 +102,7 @@ async function main(): Promise<void> {
     //    — ready for any signTypedData implementation. ethers v6 infers
     //    `EIP712Domain` automatically; viem / wallet RPCs accept the same
     //    structure as-is.
-    const typedData = smartAccount.getUserOperationEip712TypedData(userOp, chainId)
+    const typedData = Simple7702Account.getUserOperationEip712Data(userOp, chainId)
     userOp.signature = await wallet.signTypedData(
         typedData.domain,
         typedData.types,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "abstractionkit": "^0.3.7",
+        "abstractionkit": "^0.3.8",
         "cbor": "^10.0.12",
         "dotenv": "^16.5.0",
         "viem": "^2.44.4"
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/abstractionkit": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.7.tgz",
-      "integrity": "sha512-ye2AY5e2qMJGLWsC1CE00hF+DlhZqwOqAuYMxWCfI5ya+mkrVNHmQf6ZIeKCX/CLNRV/3kLwVemKMGksjjkm3g==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.8.tgz",
+      "integrity": "sha512-FDzxqQf5XSEsjDQdUtS4gnB8FHcRZg9BKBtfmdW2Fo2TlTDbsoieYPveRBdBg7dPr2qV/2PFotjyv3o6pdik1w==",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "abstractionkit": "^0.3.7",
+    "abstractionkit": "^0.3.8",
     "cbor": "^10.0.12",
     "dotenv": "^16.5.0",
     "viem": "^2.44.4"

--- a/recovery/recovery.ts
+++ b/recovery/recovery.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
     //the SafeAccount object for the following useroperations
     let smartAccount = SafeAccount.initializeNewAccount(
         [ownerPublicAddress],
+        { c2Nonce: BigInt(Date.now()) },
     )
 
     console.log("Account address(sender) : " + smartAccount.accountAddress)

--- a/spend-permission/spend-permission.ts
+++ b/spend-permission/spend-permission.ts
@@ -3,12 +3,12 @@ import {
     SafeAccountV0_3_0 as SafeAccount,
     AllowanceModule,
     CandidePaymaster,
-    ZeroAddress
 } from "abstractionkit";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createPublicClient, http, parseAbi } from "viem";
 
 const ERC20_ABI = parseAbi(["function balanceOf(address owner) view returns (uint256)"]);
+const allowanceTransferAmount = 1n;
 
 async function main(): Promise<void> {
     const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
@@ -35,8 +35,8 @@ async function main(): Promise<void> {
         args: [sourceSafeAccount.accountAddress as `0x${string}`],
     });
 
-    if (sourceSafeAccountBalance <= 2n) {
-        console.log("Please fund the Safe Account with some tokens first");
+    if (sourceSafeAccountBalance < allowanceTransferAmount) {
+        console.log(`Please fund the Safe Account with at least ${allowanceTransferAmount} token first`);
         console.log("Safe Account Address: " + sourceSafeAccount.accountAddress);
         console.log("Token: ", allowanceToken);
         console.log("Network Chain ID ", chainId.toString());
@@ -50,23 +50,34 @@ async function main(): Promise<void> {
 
     const allowanceModule = new AllowanceModule();
 
-    // Need to be enabled only once
-    const enableModuleMetaTransaction = allowanceModule.createEnableModuleMetaTransaction(sourceSafeAccount.accountAddress);
+    const setupTransactions = [];
+    const allowanceModuleEnabled = await sourceSafeAccount.isModuleEnabled(
+        nodeUrl,
+        allowanceModule.moduleAddress,
+    );
+
+    // Need to be enabled only once. Skipping this on reruns keeps the example idempotent.
+    if (!allowanceModuleEnabled) {
+        setupTransactions.push(
+            allowanceModule.createEnableModuleMetaTransaction(sourceSafeAccount.accountAddress)
+        );
+    }
 
     const addDelegateMetaTransaction = allowanceModule.createAddDelegateMetaTransaction(delegateSafeAccount.accountAddress);
+    setupTransactions.push(addDelegateMetaTransaction);
 
     const setAllowanceMetaTransaction =
         allowanceModule.createRecurringAllowanceMetaTransaction(
             delegateSafeAccount.accountAddress, // The address of the delegate to whom the recurring allowance is given.
             allowanceToken, // The address of the token for which the allowance is set. 
-            1n, // The amount of the token allowed for the delegate.
+            allowanceTransferAmount, // The amount of the token allowed for the delegate.
             3n, // The time period (in minutes) after which the allowance resets.
             0n, // The delay in minutes before the allowance can be used.
         );
 
     let setAllowanceUserOp =
         await sourceSafeAccount.createUserOperation(
-            [enableModuleMetaTransaction, addDelegateMetaTransaction, setAllowanceMetaTransaction],
+            [...setupTransactions, setAllowanceMetaTransaction],
             nodeUrl,
             bundlerUrl,
         );
@@ -103,13 +114,13 @@ async function main(): Promise<void> {
 
     /* The Delegate can now transfer the tokens on behaf of the Source Safe Account */
 
-    const transferRecipient = ZeroAddress;
+    const transferRecipient = delegateOwnerPublicAddress;
     const allowanceTransferMetaTransaction =
         allowanceModule.createAllowanceTransferMetaTransaction(
             sourceSafeAccount.accountAddress, // The safe address from which the allowance is being transferred
             allowanceToken,
             transferRecipient, // The recipient address of the allowance transfer.
-            2n, // The amount of tokens to be transferred.
+            allowanceTransferAmount, // The amount of tokens to be transferred.
             delegateSafeAccount.accountAddress, // The delegate address managing the transfer.
         );
 
@@ -145,4 +156,3 @@ async function main(): Promise<void> {
 }
 
 main();
-


### PR DESCRIPTION
## Summary
- bump abstractionkit to 0.3.8
- migrate removed getDelegatedAddress helper usage to JsonRpcNode
- update EIP-7702 typed-data examples to the static getUserOperationEip712Data helper
- include typed-data-only Safe Unified Account external signer example coverage
- make stateful examples rerunnable against public endpoints

## Runtime fixes
- sponsor Safe 1.5 batch example with CandidePaymaster
- use fresh c2Nonce values for recovery and multichain guardian setup examples
- make spend-permission idempotent and transfer to a valid recipient
- exit nonzero from add-guardian on uncaught errors

## Verification
- npm run build
- ran all 35 example entrypoints against configured endpoints
- reran previously failing examples after fixes: batch-transactions-1-5-0, recovery, spend-permission, add-guardian

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Candide paymaster integration enabling automated transaction sponsorship
  * External signer support with typed-data signing capability

* **Improvements**
  * Smart account initialization now uses time-based nonces for uniqueness
  * Refined delegation verification for EIP-7702 accounts via node-based checks
  * Idempotent allowance module setup and adjusted allowance transfer behavior
  * Streamlined EIP-712 signing flow

* **Chores**
  * Updated abstractionkit dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit-examples/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->