### PR TITLE
docs(eip-7702): add sponsored v0.8 -> v0.9 migration example for Simple7702

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ npx ts-node <folder>/<script>.ts
 | EIP-7702 EP v0.9 | `eip-7702/simple-account/` | `03-upgrade-eoa-ep-v09.ts` |
 | EIP-7702 revoke delegation | `eip-7702/simple-account/` | `04-revoke-delegation.ts` |
 | EIP-7702 typed-data builder (drive signTypedData yourself) | `eip-7702/simple-account/` | `07-typed-data-builder.ts` |
+| EIP-7702 migrate v0.8 → v0.9 (sponsored, no revoke) | `eip-7702/simple-account/` | `08-migrate-v08-to-v09.ts` |
 | Debug with Tenderly | `simulate-with-tenderly/` | `simulate-with-tenderly.ts` |
 | Multichain-chain add owner | `chain-abstraction/` | `add-owner.ts` |
 | Multichain add guardian | `chain-abstraction/` | `add-guardian.ts` |

--- a/eip-7702/simple-account/08-migrate-v08-to-v09.ts
+++ b/eip-7702/simple-account/08-migrate-v08-to-v09.ts
@@ -2,8 +2,6 @@ import { loadEnv, getOrCreateOwner } from '../../utils/env'
 import {
     Simple7702Account,
     Simple7702AccountV09,
-    getFunctionSelector,
-    createCallData,
     createAndSignEip7702DelegationAuthorization,
     CandidePaymaster,
 } from "abstractionkit"
@@ -28,9 +26,8 @@ import {
 // This script is self-contained. It runs two phases:
 //   Phase 1 — delegate the EOA to v0.8        (sponsored, single-phase paymaster)
 //   Phase 2 — migrate the EOA to v0.9         (sponsored, commit/finalize paymaster)
-// Each phase mints an NFT to prove the account executes at that EntryPoint.
-
-const NFT_CONTRACT = "0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336"
+// Each phase's UserOperation carries a no-op call: the point is the EIP-7702
+// delegation it sets, not any on-chain action.
 
 async function main(): Promise<void> {
     const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
@@ -38,12 +35,9 @@ async function main(): Promise<void> {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    // Shared demo action: mint one NFT to the EOA.
-    const mintNft = {
-        to: NFT_CONTRACT,
-        value: 0n,
-        data: createCallData(getFunctionSelector('mint(address)'), ["address"], [eoaAddress]),
-    }
+    // No-op self-call. Each UserOperation only needs to carry the EIP-7702
+    // delegation; this call does nothing on-chain.
+    const noOp = { to: eoaAddress, value: 0n, data: "0x" }
 
     // ═════════════════════════════════════════════════════════════════════════
     // Phase 1 — Delegate the EOA to the v0.8 implementation (sponsored)
@@ -52,7 +46,7 @@ async function main(): Promise<void> {
     console.log(`Phase 1: delegating EOA to v0.8 impl ${v08.delegateeAddress}`)
 
     let v08Op = await v08.createUserOperation(
-        [mintNft],
+        [noOp],
         nodeUrl,
         bundlerUrl,
         { eip7702Auth: { chainId } },
@@ -78,14 +72,12 @@ async function main(): Promise<void> {
 
     const v08Receipt = await (await v08.sendUserOperation(v08Op, bundlerUrl)).included()
     if (v08Receipt == null || !v08Receipt.success) {
-        console.log("Phase 1 failed — could not establish v0.8 delegation. Aborting.")
-        return
+        throw new Error("Phase 1 failed — could not establish v0.8 delegation.")
     }
     console.log(`Phase 1 included: ${v08Receipt.receipt.transactionHash}`)
 
     if (!(await v08.isDelegatedToThisAccount(nodeUrl))) {
-        console.log("EOA is not delegated to the v0.8 impl. Aborting migration.")
-        return
+        throw new Error("EOA is not delegated to the v0.8 impl after Phase 1.")
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -95,7 +87,7 @@ async function main(): Promise<void> {
     console.log(`Phase 2: migrating EOA to v0.9 impl ${v09.delegateeAddress}`)
 
     let v09Op = await v09.createUserOperation(
-        [mintNft],
+        [noOp],
         nodeUrl,
         bundlerUrl,
         { eip7702Auth: { chainId } },
@@ -133,8 +125,7 @@ async function main(): Promise<void> {
 
     const v09Receipt = await (await v09.sendUserOperation(v09Op, bundlerUrl)).included()
     if (v09Receipt == null || !v09Receipt.success) {
-        console.log("Phase 2 failed — migration UserOperation was not included successfully.")
-        return
+        throw new Error("Phase 2 failed — migration UserOperation was not included successfully.")
     }
     console.log(`Phase 2 included: ${v09Receipt.receipt.transactionHash}`)
 
@@ -151,11 +142,13 @@ async function main(): Promise<void> {
     console.log(`  Delegated to v0.9 now:   ${onV09}`)
     console.log(`  Still delegated to v0.8: ${stillOnV08}`)
 
-    if (onV09 && !stillOnV08) {
-        console.log("Migration complete: EOA moved from EntryPoint v0.8 to v0.9, fully sponsored.")
-    } else {
-        console.log("Migration did not produce the expected delegation state.")
+    if (!onV09 || stillOnV08) {
+        throw new Error("Migration did not produce the expected delegation state.")
     }
+    console.log("Migration complete: EOA moved from EntryPoint v0.8 to v0.9, fully sponsored.")
 }
 
-main()
+main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err)
+    process.exitCode = 1
+})

--- a/eip-7702/simple-account/08-migrate-v08-to-v09.ts
+++ b/eip-7702/simple-account/08-migrate-v08-to-v09.ts
@@ -1,0 +1,161 @@
+import { loadEnv, getOrCreateOwner } from '../../utils/env'
+import {
+    Simple7702Account,
+    Simple7702AccountV09,
+    getFunctionSelector,
+    createCallData,
+    createAndSignEip7702DelegationAuthorization,
+    CandidePaymaster,
+} from "abstractionkit"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migrate a delegated Simple7702 EOA from EntryPoint v0.8 to v0.9 — gas-sponsored
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Key concept:
+//   v0.8 and v0.9 are SEPARATE implementation contracts, each behind its own
+//   EntryPoint:
+//     v0.8 impl: Simple7702Account.DEFAULT_DELEGATEE_ADDRESS
+//     v0.9 impl: Simple7702AccountV09.DEFAULT_DELEGATEE_ADDRESS
+//
+//   "Migrating" is NOT an EntryPoint upgrade, and NOT a revoke. It is simply a
+//   NEW EIP-7702 authorization that re-points the EOA at the v0.9 implementation.
+//   That authorization rides inside a sponsored UserOperation on the v0.9
+//   EntryPoint, so it overwrites the old v0.8 delegation in a single op and the
+//   user pays no gas. A revoke (04-revoke-delegation.ts) would cost the EOA gas
+//   and is unnecessary here.
+//
+// This script is self-contained. It runs two phases:
+//   Phase 1 — delegate the EOA to v0.8        (sponsored, single-phase paymaster)
+//   Phase 2 — migrate the EOA to v0.9         (sponsored, commit/finalize paymaster)
+// Each phase mints an NFT to prove the account executes at that EntryPoint.
+
+const NFT_CONTRACT = "0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336"
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress: eoaAddress, privateKey } = getOrCreateOwner()
+
+    const paymaster = new CandidePaymaster(paymasterUrl)
+
+    // Shared demo action: mint one NFT to the EOA.
+    const mintNft = {
+        to: NFT_CONTRACT,
+        value: 0n,
+        data: createCallData(getFunctionSelector('mint(address)'), ["address"], [eoaAddress]),
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Phase 1 — Delegate the EOA to the v0.8 implementation (sponsored)
+    // ═════════════════════════════════════════════════════════════════════════
+    const v08 = new Simple7702Account(eoaAddress)
+    console.log(`Phase 1: delegating EOA to v0.8 impl ${v08.delegateeAddress}`)
+
+    let v08Op = await v08.createUserOperation(
+        [mintNft],
+        nodeUrl,
+        bundlerUrl,
+        { eip7702Auth: { chainId } },
+    )
+
+    // eip7702Auth is null if the EOA is already delegated to this impl.
+    if (v08Op.eip7702Auth) {
+        v08Op.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+            BigInt(v08Op.eip7702Auth.chainId),
+            v08Op.eip7702Auth.address,
+            BigInt(v08Op.eip7702Auth.nonce),
+            privateKey,
+        )
+    }
+
+    // v0.8 EntryPoint: single-phase paymaster sponsorship (see 01-upgrade-eoa.ts).
+    const v08Sponsored = await paymaster.createSponsorPaymasterUserOperation(
+        v08, v08Op, bundlerUrl, sponsorshipPolicyId,
+    )
+    v08Op = v08Sponsored.userOperation
+
+    v08Op.signature = v08.signUserOperation(v08Op, privateKey, chainId)
+
+    const v08Receipt = await (await v08.sendUserOperation(v08Op, bundlerUrl)).included()
+    if (v08Receipt == null || !v08Receipt.success) {
+        console.log("Phase 1 failed — could not establish v0.8 delegation. Aborting.")
+        return
+    }
+    console.log(`Phase 1 included: ${v08Receipt.receipt.transactionHash}`)
+
+    if (!(await v08.isDelegatedToThisAccount(nodeUrl))) {
+        console.log("EOA is not delegated to the v0.8 impl. Aborting migration.")
+        return
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Phase 2 — Migrate the EOA to the v0.9 implementation (sponsored, no revoke)
+    // ═════════════════════════════════════════════════════════════════════════
+    const v09 = new Simple7702AccountV09(eoaAddress)
+    console.log(`Phase 2: migrating EOA to v0.9 impl ${v09.delegateeAddress}`)
+
+    let v09Op = await v09.createUserOperation(
+        [mintNft],
+        nodeUrl,
+        bundlerUrl,
+        { eip7702Auth: { chainId } },
+    )
+
+    // The EOA is on the v0.8 impl, not v0.9, so eip7702Auth is returned: sign a
+    // fresh authorization re-pointing the EOA at the v0.9 impl. Submitting it
+    // overwrites the v0.8 delegation — no separate revoke transaction needed.
+    if (!v09Op.eip7702Auth) {
+        console.log("No eip7702Auth returned — EOA already on v0.9. Nothing to migrate.")
+        return
+    }
+    v09Op.eip7702Auth = createAndSignEip7702DelegationAuthorization(
+        BigInt(v09Op.eip7702Auth.chainId),
+        v09Op.eip7702Auth.address,
+        BigInt(v09Op.eip7702Auth.nonce),
+        privateKey,
+    )
+
+    // v0.9 EntryPoint: commit/finalize paymaster flow (see 03-upgrade-eoa-ep-v09.ts).
+    // The paymaster reads the v0.9 EntryPoint from the account — no entrypoint override.
+    console.log("Paymaster commit: estimating gas...")
+    const v09Commit = await paymaster.createSponsorPaymasterUserOperation(
+        v09, v09Op, bundlerUrl, sponsorshipPolicyId, { signingPhase: "commit" },
+    )
+    v09Op = v09Commit.userOperation
+
+    v09Op.signature = v09.signUserOperation(v09Op, privateKey, chainId)
+
+    console.log("Paymaster finalize: getting final paymasterData...")
+    const v09Finalize = await paymaster.createSponsorPaymasterUserOperation(
+        v09, v09Op, bundlerUrl, sponsorshipPolicyId, { signingPhase: "finalize" },
+    )
+    v09Op = v09Finalize.userOperation
+
+    const v09Receipt = await (await v09.sendUserOperation(v09Op, bundlerUrl)).included()
+    if (v09Receipt == null || !v09Receipt.success) {
+        console.log("Phase 2 failed — migration UserOperation was not included successfully.")
+        return
+    }
+    console.log(`Phase 2 included: ${v09Receipt.receipt.transactionHash}`)
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Verify the final delegation state
+    // ═════════════════════════════════════════════════════════════════════════
+    const onV09 = await v09.isDelegatedToThisAccount(nodeUrl)
+    const stillOnV08 = await v08.isDelegatedToThisAccount(nodeUrl)
+
+    console.log("──────────────────────────────────────────────")
+    console.log("Migration summary")
+    console.log(`  v0.8 impl:               ${v08.delegateeAddress}`)
+    console.log(`  v0.9 impl:               ${v09.delegateeAddress}`)
+    console.log(`  Delegated to v0.9 now:   ${onV09}`)
+    console.log(`  Still delegated to v0.8: ${stillOnV08}`)
+
+    if (onV09 && !stillOnV08) {
+        console.log("Migration complete: EOA moved from EntryPoint v0.8 to v0.9, fully sponsored.")
+    } else {
+        console.log("Migration did not produce the expected delegation state.")
+    }
+}
+
+main()


### PR DESCRIPTION
## Summary
- Adds `eip-7702/simple-account/08-migrate-v08-to-v09.ts`: a self-contained, fully gas-sponsored migration of a delegated Simple7702 EOA from EntryPoint v0.8 to v0.9.
- Migration is done via a **new EIP-7702 authorization** re-pointing the EOA at the v0.9 implementation contract — no revoke, no user gas. The new delegation overwrites the old v0.8 one inside the sponsored UserOp.
- Phase 1 delegates to v0.8 (single-phase paymaster, mirrors `01`); Phase 2 migrates to v0.9 (commit/finalize paymaster, mirrors `03`); each phase mints an NFT and the script verifies the before/after delegation state.
- Registers the example in the `AGENTS.md`/`CLAUDE.md` table.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` clean for the new file
- [x] Ran end-to-end on Arbitrum Sepolia: both phases included, `Delegated to v0.9: true`, `Still delegated to v0.8: false`, fully sponsored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migration example to upgrade EIP-7702 delegated accounts from EntryPoint v0.8 to v0.9 with sponsored execution and verification steps.

* **Documentation**
  * Added the new migration example to the AbstractionKit examples list and included usage/logging for migration outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit-examples/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->