### PR TITLE
Add deployed-Safe EntryPoint v0.7 → v0.9 migration example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ npx ts-node <folder>/<script>.ts
 | Pay gas with ERC-20 | `pay-gas-in-erc20/` | `pay-gas-in-erc20.ts` |
 | Batch multiple txs | `batch-transactions/` | `batch-transactions.ts` |
 | Account recovery | `recovery/` | `recovery.ts` |
+| Upgrade a deployed Safe EntryPoint v0.7 → v0.9 (swap 4337 module + fallback handler, sponsored) | `migrate-safe-v07-to-v09/` | `migrate-safe-v07-to-v09.ts` |
 | EIP-7702 delegation (EntryPoint v0.9) | `eip-7702/simple-account/` | `01-upgrade-eoa.ts` |
 | EIP-7702 pay gas in ERC-20 | `eip-7702/simple-account/` | `02-upgrade-eoa-erc20-gas.ts` |
 | EIP-7702 two-phase parallel signing (sponsor latency optimization) | `eip-7702/simple-account/` | `03-parallel-signing.ts` |
@@ -212,6 +213,32 @@ const receipt = await response.included();
 | `Simple7702Account` | EIP-7702 legacy v0.8 (used in the v0.8→v0.9 migration example) | v0.8 | `signUserOperationWithSigner(op, signer, chainId)` |
 | `Calibur7702Account` | EIP-7702 Calibur (passkeys, key mgmt) | v0.8 (default) | `signUserOperationWithSigner(op, signer, chainId)` |
 
+> **Module version ≠ EntryPoint version.** The Safe class names refer to the Safe
+> *4337 module* version, not the EntryPoint. `SafeAccountV0_3_0` is the "0.3.0
+> module" Safe and runs on **EntryPoint v0.7** (not v0.8); `SafeAccountV0_2_0` is
+> the "0.2.0 module" on **EntryPoint v0.6**. There is no Safe class for EntryPoint
+> v0.8 — the SDK jumps from the v0.7 Safe straight to `SafeMultiChainSigAccountV1`
+> on **v0.9**. See the `EntryPoint` column above for the authoritative mapping.
+
+## Paymaster Patterns
+
+**Recommended: `Erc7677Paymaster`** — it speaks the ERC-7677 standard, so it works
+with any compliant provider (Candide, Pimlico, Alchemy) and is portable. Sponsor in
+a single call: `createPaymasterUserOperation(account, op, bundlerUrl, context)`. Used
+by `sponsor-gas/`.
+
+`CandidePaymaster` is the Candide-specific client (sponsorship + ERC-20 gas). It also
+sponsors in a **single** call — `createSponsorPaymasterUserOperation(...)` — on every
+EntryPoint, including v0.9. The two-phase `commit` → sign → `finalize` flow seen in
+some examples is an **optional latency optimization** (sign in parallel with the
+paymaster's final-data fetch; see `eip-7702/simple-account/03-parallel-signing.ts`),
+**not** a requirement for v0.9.
+
+The v0.9 `commit`/`finalize` split lets you sign in parallel with the paymaster's
+final-data fetch to cut latency; it is the established pattern for `CandidePaymaster`
+on EntryPoint v0.9. The single-call `Erc7677Paymaster` path also works on v0.9 when
+you don't need that optimization.
+
 ## Common Commands
 
 ```bash
@@ -220,6 +247,9 @@ npm install
 
 # Run an example
 npx ts-node sponsor-gas/sponsor-gas.ts
+
+# Type-check every example against the installed abstractionkit (no emit)
+npm run check
 
 # Build TypeScript
 npm run build

--- a/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
+++ b/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
@@ -1,0 +1,261 @@
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import {
+    SafeAccountV0_3_0,
+    SafeMultiChainSigAccountV1,
+    MetaTransaction,
+    CandidePaymaster,
+    getFunctionSelector,
+    createCallData,
+} from "abstractionkit"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migrate a DEPLOYED Safe smart account from EntryPoint v0.7 to EntryPoint v0.9
+// (the "0.3.0 module" Safe → the multi-chain-signature module), gas-sponsored.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Account classes involved (abstractionkit has no Safe class for EntryPoint v0.8;
+// the SDK-supported pre-v0.9 Safe is the v0.3.0-module account on EntryPoint v0.7):
+//
+//   SafeAccountV0_3_0           → EntryPoint v0.7, Safe4337Module
+//                                 0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
+//   SafeMultiChainSigAccountV1  → EntryPoint v0.9, Safe4337MultiChainSignatureModule
+//                                 0x22939E839e3c0F479B713eAF95e0df128554AEAd
+//
+// What "upgrading" a deployed Safe means here:
+//   A Safe routes ERC-4337 validation through its FALLBACK HANDLER and executes
+//   via an ENABLED MODULE. For both versions the 4337 module is BOTH the enabled
+//   module AND the fallback handler. So moving a deployed Safe from one EntryPoint
+//   to another is purely three self-calls on the Safe:
+//     1. disableModule(oldModule)
+//     2. enableModule(newModule)
+//     3. setFallbackHandler(newModule)
+//   After these land, the Safe validates/executes through the new module on the
+//   new EntryPoint. The Safe singleton (master copy) does NOT change.
+//
+// STORAGE CLEARING — none required.
+//   Both Safe4337Module (v0.7) and Safe4337MultiChainSignatureModule (v0.9) are
+//   completely STATELESS: zero state variables, no mappings, no sstore, no
+//   per-account nonce/cache (the nonce lives in the EntryPoint, not the module).
+//   Every signature check is computed on the fly from the UserOperation fields.
+//   So there is no stale module storage to wipe when swapping modules — the three
+//   transactions above are the whole migration.
+//
+// The migration batch is validated and executed by the OLD (v0.7) module on the
+// OLD EntryPoint. Disabling the module that is mid-execution is safe: validation
+// has already completed and the EntryPoint will not re-enter the module for this
+// op. This is exactly how the SDK's own v0.6→v0.7 migration helper works; there is
+// no built-in v0.9 helper, so the three MetaTransactions are composed below.
+//
+// This script is self-contained and runs three phases on Arbitrum Sepolia:
+//   Phase 1 — deploy a fresh SafeAccountV0_3_0 (EP v0.7)        [sponsored]
+//   Phase 2 — migrate it to the v0.9 multi-chain module (EP v0.9) [sponsored]
+//   Phase 3 — prove the upgraded account works on EP v0.9 (mint)  [sponsored]
+//
+// (You could fuse Phase 1 + Phase 2 into a single deploy-and-migrate op — the
+//  deploy initCode sets the v0.7 module, and that op's callData carries the
+//  migration batch. Kept separate here so each state is observable on-chain.)
+
+const OLD_MODULE = SafeAccountV0_3_0.DEFAULT_SAFE_4337_MODULE_ADDRESS // EP v0.7 module
+const NEW_MODULE = SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS // EP v0.9 module
+
+// Safe stores its fallback handler at a fixed slot:
+//   keccak256("fallback_manager.handler.address")
+const FALLBACK_HANDLER_SLOT =
+    "0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5"
+
+const EXPLORER = "https://sepolia.arbiscan.io"
+
+/**
+ * Compose the three MetaTransactions that move a deployed Safe from the v0.7
+ * module to the v0.9 multi-chain-signature module. Mirrors the SDK's existing
+ * createMigrateToSafeAccountV0_3_0MetaTransactions (v0.6 → v0.7), retargeted to
+ * the v0.9 module. No storage clearing step exists because neither module keeps
+ * per-account storage.
+ *
+ * Spelled out here so the migration is fully visible. Newer abstractionkit
+ * releases also expose this directly:
+ *   oldAccount.createMigrateToSafeMultiChainSigAccountV1MetaTransactions(nodeUrl)
+ * and a generic SafeAccount.createModuleMigrationMetaTransactions(nodeUrl, from, to).
+ */
+async function createMigrateToV09MetaTransactions(
+    oldAccount: SafeAccountV0_3_0,
+    nodeUrl: string,
+): Promise<MetaTransaction[]> {
+    // Fetches the previous module in the Safe's linked list automatically
+    // (the 0x..01 sentinel for a Safe that only has the old 4337 module enabled).
+    const disableOldModule = await oldAccount.createDisableModuleMetaTransaction(
+        nodeUrl,
+        OLD_MODULE,
+        oldAccount.accountAddress,
+    )
+
+    const enableNewModule = SafeAccountV0_3_0.createEnableModuleMetaTransaction(
+        NEW_MODULE,
+        oldAccount.accountAddress,
+    )
+
+    const setFallbackHandler: MetaTransaction = {
+        to: oldAccount.accountAddress,
+        value: 0n,
+        data: createCallData(
+            "0xf08a0323", // setFallbackHandler(address)
+            ["address"],
+            [NEW_MODULE],
+        ),
+    }
+
+    return [disableOldModule, enableNewModule, setFallbackHandler]
+}
+
+/** Read a single storage slot via raw JSON-RPC. */
+async function getStorageAt(nodeUrl: string, address: string, slot: string): Promise<string> {
+    const res = await fetch(nodeUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "eth_getStorageAt",
+            params: [address, slot, "latest"],
+        }),
+    })
+    const json = await res.json()
+    if (json.error) throw new Error(`eth_getStorageAt failed: ${json.error.message}`)
+    return json.result as string
+}
+
+/** Last 20 bytes of a 32-byte storage word, as a checksummable lowercase address. */
+function slotToAddress(word: string): string {
+    return "0x" + word.slice(-40).toLowerCase()
+}
+
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
+    const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
+
+    const paymaster = new CandidePaymaster(paymasterUrl)
+
+    // No-op self-call: Phase 1 only needs to DEPLOY the Safe; it does nothing else.
+    const noOp: MetaTransaction = { to: ownerPublicAddress, value: 0n, data: "0x" }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Phase 1 — Deploy a fresh Safe on EntryPoint v0.7 (the "old" account)
+    // ═════════════════════════════════════════════════════════════════════════
+    // A Safe's address is deterministic in (owners, salt). Use a unique salt per
+    // run so the demo always starts from a fresh, undeployed account and can be
+    // re-run with the same owner key. In production you'd pin/store this address.
+    const oldAccount = SafeAccountV0_3_0.initializeNewAccount([ownerPublicAddress], {
+        c2Nonce: BigInt(Date.now()),
+    })
+    const accountAddress = oldAccount.accountAddress
+    console.log("──────────────────────────────────────────────")
+    console.log(`Safe account address: ${accountAddress}`)
+    console.log(`  Explorer: ${EXPLORER}/address/${accountAddress}`)
+    console.log(`Phase 1: deploying Safe on EntryPoint v0.7 (module ${OLD_MODULE})`)
+
+    let deployOp = await oldAccount.createUserOperation([noOp], nodeUrl, bundlerUrl)
+
+    // EntryPoint v0.7 + CandidePaymaster: single-phase sponsorship.
+    deployOp = (
+        await paymaster.createSponsorPaymasterUserOperation(
+            oldAccount, deployOp, bundlerUrl, sponsorshipPolicyId,
+        )
+    ).userOperation
+
+    deployOp.signature = oldAccount.signUserOperation(deployOp, [ownerPrivateKey], chainId)
+
+    const deployReceipt = await (await oldAccount.sendUserOperation(deployOp, bundlerUrl)).included()
+    if (deployReceipt == null || !deployReceipt.success) {
+        throw new Error("Phase 1 failed — Safe deployment UserOperation was not included successfully.")
+    }
+    console.log(`Phase 1 included: ${EXPLORER}/tx/${deployReceipt.receipt.transactionHash}`)
+
+    // Sanity check: the v0.7 module is the active module on the fresh Safe.
+    if (!(await oldAccount.isModuleEnabled(nodeUrl, OLD_MODULE))) {
+        throw new Error("v0.7 module is not enabled after deployment — unexpected state.")
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Phase 2 — Migrate to the v0.9 multi-chain module (validated by v0.7 module)
+    // ═════════════════════════════════════════════════════════════════════════
+    console.log(`Phase 2: migrating to EntryPoint v0.9 (module ${NEW_MODULE})`)
+
+    const migrationBatch = await createMigrateToV09MetaTransactions(oldAccount, nodeUrl)
+
+    let migrateOp = await oldAccount.createUserOperation(migrationBatch, nodeUrl, bundlerUrl)
+
+    migrateOp = (
+        await paymaster.createSponsorPaymasterUserOperation(
+            oldAccount, migrateOp, bundlerUrl, sponsorshipPolicyId,
+        )
+    ).userOperation
+
+    migrateOp.signature = oldAccount.signUserOperation(migrateOp, [ownerPrivateKey], chainId)
+
+    const migrateReceipt = await (await oldAccount.sendUserOperation(migrateOp, bundlerUrl)).included()
+    if (migrateReceipt == null || !migrateReceipt.success) {
+        throw new Error("Phase 2 failed — migration UserOperation was not included successfully.")
+    }
+    console.log(`Phase 2 included: ${EXPLORER}/tx/${migrateReceipt.receipt.transactionHash}`)
+
+    // ── Verify the on-chain upgrade (independent of "the tx didn't revert") ──
+    const newModuleEnabled = await oldAccount.isModuleEnabled(nodeUrl, NEW_MODULE)
+    const oldModuleEnabled = await oldAccount.isModuleEnabled(nodeUrl, OLD_MODULE)
+    const fallbackHandler = slotToAddress(
+        await getStorageAt(nodeUrl, accountAddress, FALLBACK_HANDLER_SLOT),
+    )
+
+    console.log("Upgrade verification:")
+    console.log(`  new module (v0.9) enabled:  ${newModuleEnabled}`)
+    console.log(`  old module (v0.7) enabled:  ${oldModuleEnabled}`)
+    console.log(`  fallback handler is:        ${fallbackHandler}`)
+
+    if (!newModuleEnabled || oldModuleEnabled || fallbackHandler !== NEW_MODULE.toLowerCase()) {
+        throw new Error("Upgrade verification failed — account is not cleanly on the v0.9 module.")
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Phase 3 — Prove the upgraded account works on EntryPoint v0.9
+    // ═════════════════════════════════════════════════════════════════════════
+    // Attach the SAME deployed address to the v0.9 account class. nonce > 0 means
+    // no initCode; validation now routes through the v0.9 module via the fallback
+    // handler we just set. A successful mint is end-to-end proof of the upgrade.
+    console.log("Phase 3: sending a sponsored mint through the upgraded v0.9 account")
+    const newAccount = new SafeMultiChainSigAccountV1(accountAddress)
+
+    const nftContractAddress = "0x9a7af758aE5d7B6aAE84fe4C5Ba67c041dFE5336"
+    const mintCallData = createCallData(
+        getFunctionSelector("mint(address)"),
+        ["address"],
+        [accountAddress],
+    )
+    const mintTx: MetaTransaction = { to: nftContractAddress, value: 0n, data: mintCallData }
+
+    let mintOp = await newAccount.createUserOperation([mintTx], nodeUrl, bundlerUrl)
+
+    // Single-call sponsorship works on every EntryPoint, including v0.9. (The
+    // commit/finalize split in 03-parallel-signing.ts is an optional latency
+    // optimization, not a requirement.)
+    mintOp = (
+        await paymaster.createSponsorPaymasterUserOperation(
+            newAccount, mintOp, bundlerUrl, sponsorshipPolicyId,
+        )
+    ).userOperation
+
+    mintOp.signature = newAccount.signUserOperation(mintOp, [ownerPrivateKey], chainId)
+
+    const mintReceipt = await (await newAccount.sendUserOperation(mintOp, bundlerUrl)).included()
+    if (mintReceipt == null || !mintReceipt.success) {
+        throw new Error("Phase 3 failed — the upgraded v0.9 account could not execute a UserOperation.")
+    }
+    console.log(`Phase 3 included: ${EXPLORER}/tx/${mintReceipt.receipt.transactionHash}`)
+
+    console.log("──────────────────────────────────────────────")
+    console.log("Migration complete: Safe upgraded from EntryPoint v0.7 to v0.9, fully sponsored.")
+    console.log(`  Account: ${EXPLORER}/address/${accountAddress}`)
+}
+
+main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err)
+    process.exitCode = 1
+})

--- a/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
+++ b/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
@@ -6,15 +6,13 @@ import {
     CandidePaymaster,
     getFunctionSelector,
     createCallData,
+    sendJsonRpcRequest,
 } from "abstractionkit"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Migrate a DEPLOYED Safe smart account from EntryPoint v0.7 to EntryPoint v0.9
 // (the "0.3.0 module" Safe → the multi-chain-signature module), gas-sponsored.
 // ─────────────────────────────────────────────────────────────────────────────
-//
-// Account classes involved (abstractionkit has no Safe class for EntryPoint v0.8;
-// the SDK-supported pre-v0.9 Safe is the v0.3.0-module account on EntryPoint v0.7):
 //
 //   SafeAccountV0_3_0           → EntryPoint v0.7, Safe4337Module
 //                                 0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
@@ -43,17 +41,16 @@ import {
 // The migration batch is validated and executed by the OLD (v0.7) module on the
 // OLD EntryPoint. Disabling the module that is mid-execution is safe: validation
 // has already completed and the EntryPoint will not re-enter the module for this
-// op. This is exactly how the SDK's own v0.6→v0.7 migration helper works; there is
-// no built-in v0.9 helper, so the three MetaTransactions are composed below.
+// op.
 //
-// This script is self-contained and runs three phases on Arbitrum Sepolia:
-//   Phase 1 — deploy a fresh SafeAccountV0_3_0 (EP v0.7)        [sponsored]
+// This script is self-contained and runs three phases:
+//   Phase 1 — deploy a fresh SafeAccountV0_3_0 (EP v0.7)          [sponsored]
 //   Phase 2 — migrate it to the v0.9 multi-chain module (EP v0.9) [sponsored]
 //   Phase 3 — prove the upgraded account works on EP v0.9 (mint)  [sponsored]
 //
 // (You could fuse Phase 1 + Phase 2 into a single deploy-and-migrate op — the
 //  deploy initCode sets the v0.7 module, and that op's callData carries the
-//  migration batch. Kept separate here so each state is observable on-chain.)
+//  migration batch. Kept separate here so each state is observable onchain.)
 
 const OLD_MODULE = SafeAccountV0_3_0.DEFAULT_SAFE_4337_MODULE_ADDRESS // EP v0.7 module
 const NEW_MODULE = SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS // EP v0.9 module
@@ -63,19 +60,10 @@ const NEW_MODULE = SafeMultiChainSigAccountV1.DEFAULT_SAFE_4337_MODULE_ADDRESS /
 const FALLBACK_HANDLER_SLOT =
     "0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5"
 
-const EXPLORER = "https://sepolia.arbiscan.io"
-
 /**
  * Compose the three MetaTransactions that move a deployed Safe from the v0.7
- * module to the v0.9 multi-chain-signature module. Mirrors the SDK's existing
- * createMigrateToSafeAccountV0_3_0MetaTransactions (v0.6 → v0.7), retargeted to
- * the v0.9 module. No storage clearing step exists because neither module keeps
- * per-account storage.
- *
- * Spelled out here so the migration is fully visible. Newer abstractionkit
- * releases also expose this directly:
- *   oldAccount.createMigrateToSafeMultiChainSigAccountV1MetaTransactions(nodeUrl)
- * and a generic SafeAccount.createModuleMigrationMetaTransactions(nodeUrl, from, to).
+ * module to the v0.9 multi-chain-signature module. No storage clearing step exists 
+ * because neither module keeps per-account storage.
  */
 async function createMigrateToV09MetaTransactions(
     oldAccount: SafeAccountV0_3_0,
@@ -107,21 +95,10 @@ async function createMigrateToV09MetaTransactions(
     return [disableOldModule, enableNewModule, setFallbackHandler]
 }
 
-/** Read a single storage slot via raw JSON-RPC. */
+/** Read a single storage slot via the SDK's JSON-RPC helper. */
 async function getStorageAt(nodeUrl: string, address: string, slot: string): Promise<string> {
-    const res = await fetch(nodeUrl, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "eth_getStorageAt",
-            params: [address, slot, "latest"],
-        }),
-    })
-    const json = await res.json()
-    if (json.error) throw new Error(`eth_getStorageAt failed: ${json.error.message}`)
-    return json.result as string
+    const result = await sendJsonRpcRequest(nodeUrl, "eth_getStorageAt", [address, slot, "latest"])
+    return result as string
 }
 
 /** Last 20 bytes of a 32-byte storage word, as a checksummable lowercase address. */
@@ -150,7 +127,6 @@ async function main(): Promise<void> {
     const accountAddress = oldAccount.accountAddress
     console.log("──────────────────────────────────────────────")
     console.log(`Safe account address: ${accountAddress}`)
-    console.log(`  Explorer: ${EXPLORER}/address/${accountAddress}`)
     console.log(`Phase 1: deploying Safe on EntryPoint v0.7 (module ${OLD_MODULE})`)
 
     let deployOp = await oldAccount.createUserOperation([noOp], nodeUrl, bundlerUrl)
@@ -168,7 +144,7 @@ async function main(): Promise<void> {
     if (deployReceipt == null || !deployReceipt.success) {
         throw new Error("Phase 1 failed — Safe deployment UserOperation was not included successfully.")
     }
-    console.log(`Phase 1 included: ${EXPLORER}/tx/${deployReceipt.receipt.transactionHash}`)
+    console.log(`Phase 1 included: ${deployReceipt.receipt.transactionHash}`)
 
     // Sanity check: the v0.7 module is the active module on the fresh Safe.
     if (!(await oldAccount.isModuleEnabled(nodeUrl, OLD_MODULE))) {
@@ -196,7 +172,7 @@ async function main(): Promise<void> {
     if (migrateReceipt == null || !migrateReceipt.success) {
         throw new Error("Phase 2 failed — migration UserOperation was not included successfully.")
     }
-    console.log(`Phase 2 included: ${EXPLORER}/tx/${migrateReceipt.receipt.transactionHash}`)
+    console.log(`Phase 2 included: ${migrateReceipt.receipt.transactionHash}`)
 
     // ── Verify the on-chain upgrade (independent of "the tx didn't revert") ──
     const newModuleEnabled = await oldAccount.isModuleEnabled(nodeUrl, NEW_MODULE)
@@ -248,11 +224,11 @@ async function main(): Promise<void> {
     if (mintReceipt == null || !mintReceipt.success) {
         throw new Error("Phase 3 failed — the upgraded v0.9 account could not execute a UserOperation.")
     }
-    console.log(`Phase 3 included: ${EXPLORER}/tx/${mintReceipt.receipt.transactionHash}`)
+    console.log(`Phase 3 included: ${mintReceipt.receipt.transactionHash}`)
 
     console.log("──────────────────────────────────────────────")
     console.log("Migration complete: Safe upgraded from EntryPoint v0.7 to v0.9, fully sponsored.")
-    console.log(`  Account: ${EXPLORER}/address/${accountAddress}`)
+    console.log(`  Account: ${accountAddress}`)
 }
 
 main().catch((err) => {

--- a/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
+++ b/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
@@ -3,7 +3,7 @@ import {
     SafeAccountV0_3_0,
     SafeMultiChainSigAccountV1,
     MetaTransaction,
-    CandidePaymaster,
+    Erc7677Paymaster,
     getFunctionSelector,
     createCallData,
     sendJsonRpcRequest,
@@ -62,7 +62,7 @@ const FALLBACK_HANDLER_SLOT =
 
 /**
  * Compose the three MetaTransactions that move a deployed Safe from the v0.7
- * module to the v0.9 multi-chain-signature module. No storage clearing step exists 
+ * module to the v0.9 multi-chain-signature module. No storage clearing step exists
  * because neither module keeps per-account storage.
  */
 async function createMigrateToV09MetaTransactions(
@@ -95,12 +95,6 @@ async function createMigrateToV09MetaTransactions(
     return [disableOldModule, enableNewModule, setFallbackHandler]
 }
 
-/** Read a single storage slot via the SDK's JSON-RPC helper. */
-async function getStorageAt(nodeUrl: string, address: string, slot: string): Promise<string> {
-    const result = await sendJsonRpcRequest(nodeUrl, "eth_getStorageAt", [address, slot, "latest"])
-    return result as string
-}
-
 /** Last 20 bytes of a 32-byte storage word, as a checksummable lowercase address. */
 function slotToAddress(word: string): string {
     return "0x" + word.slice(-40).toLowerCase()
@@ -110,7 +104,10 @@ async function main(): Promise<void> {
     const { chainId, bundlerUrl, nodeUrl, paymasterUrl, sponsorshipPolicyId } = loadEnv()
     const { publicAddress: ownerPublicAddress, privateKey: ownerPrivateKey } = getOrCreateOwner()
 
-    const paymaster = new CandidePaymaster(paymasterUrl)
+    const paymaster = new Erc7677Paymaster(paymasterUrl)
+    // Candide and Pimlico read `sponsorshipPolicyId`; Alchemy reads `policyId`.
+    // Send both so the same context is portable across providers; empty = public gas policies.
+    const context = sponsorshipPolicyId ? { sponsorshipPolicyId, policyId: sponsorshipPolicyId } : {}
 
     // No-op self-call: Phase 1 only needs to DEPLOY the Safe; it does nothing else.
     const noOp: MetaTransaction = { to: ownerPublicAddress, value: 0n, data: "0x" }
@@ -131,10 +128,10 @@ async function main(): Promise<void> {
 
     let deployOp = await oldAccount.createUserOperation([noOp], nodeUrl, bundlerUrl)
 
-    // EntryPoint v0.7 + CandidePaymaster: single-phase sponsorship.
+    // Single ERC-7677 sponsorship call — works on every EntryPoint, v0.7 included.
     deployOp = (
-        await paymaster.createSponsorPaymasterUserOperation(
-            oldAccount, deployOp, bundlerUrl, sponsorshipPolicyId,
+        await paymaster.createPaymasterUserOperation(
+            oldAccount, deployOp, bundlerUrl, context
         )
     ).userOperation
 
@@ -161,8 +158,8 @@ async function main(): Promise<void> {
     let migrateOp = await oldAccount.createUserOperation(migrationBatch, nodeUrl, bundlerUrl)
 
     migrateOp = (
-        await paymaster.createSponsorPaymasterUserOperation(
-            oldAccount, migrateOp, bundlerUrl, sponsorshipPolicyId,
+        await paymaster.createPaymasterUserOperation(
+            oldAccount, migrateOp, bundlerUrl, context
         )
     ).userOperation
 
@@ -178,7 +175,7 @@ async function main(): Promise<void> {
     const newModuleEnabled = await oldAccount.isModuleEnabled(nodeUrl, NEW_MODULE)
     const oldModuleEnabled = await oldAccount.isModuleEnabled(nodeUrl, OLD_MODULE)
     const fallbackHandler = slotToAddress(
-        await getStorageAt(nodeUrl, accountAddress, FALLBACK_HANDLER_SLOT),
+        await sendJsonRpcRequest(nodeUrl, "eth_getStorageAt", [accountAddress, FALLBACK_HANDLER_SLOT, "latest"]) as string,
     )
 
     console.log("Upgrade verification:")
@@ -209,12 +206,9 @@ async function main(): Promise<void> {
 
     let mintOp = await newAccount.createUserOperation([mintTx], nodeUrl, bundlerUrl)
 
-    // Single-call sponsorship works on every EntryPoint, including v0.9. (The
-    // commit/finalize split in 03-parallel-signing.ts is an optional latency
-    // optimization, not a requirement.)
     mintOp = (
-        await paymaster.createSponsorPaymasterUserOperation(
-            newAccount, mintOp, bundlerUrl, sponsorshipPolicyId,
+        await paymaster.createPaymasterUserOperation(
+            newAccount, mintOp, bundlerUrl, context
         )
     ).userOperation
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This repo provides examples on how to use abstractionkit library by Candide",
   "scripts": {
     "build": "rimraf dist && tsc",
+    "check": "tsc --noEmit",
     "clean": "rimraf dist",
     "format": "prettier --write src/**/*.ts",
     "lint": "eslint src/**/*.ts"


### PR DESCRIPTION
## What

Adds `migrate-safe-v07-to-v09/` — a self-contained, gas-sponsored example showing how to upgrade a **deployed** Safe smart account from **EntryPoint v0.7** (`SafeAccountV0_3_0`) to **EntryPoint v0.9** (`SafeMultiChainSigAccountV1`).

The upgrade is purely three Safe self-calls — `disableModule(old)` + `enableModule(new)` + `setFallbackHandler(new)` — because for Safe 4337 accounts the module is both the enabled module and the fallback handler. **No storage clearing is required**: both the v0.7 `Safe4337Module` and the v0.9 `Safe4337MultiChainSignatureModule` are stateless.

The script runs three phases on Arbitrum Sepolia:
1. Deploy a fresh Safe on EP v0.7
2. Migrate it to the v0.9 module (validated/executed by the old module on EP v0.7)
3. Prove the upgraded account works on EP v0.9 (sponsored mint)

It verifies the upgrade on-chain (`isModuleEnabled` + fallback-handler storage slot) and prints explorer links. A unique `c2Nonce` salt makes it re-runnable.

## Verified live

Ran end-to-end on Arbitrum Sepolia; account fully migrated (v0.9 module enabled, v0.7 disabled, fallback handler = v0.9 module), all three UserOperations sponsored and included, with Phase 1/2 through EntryPoint v0.7 and Phase 3 through EntryPoint v0.9.

## Docs (`AGENTS.md`)

- Feature-table row for the new example
- "Module version ≠ EntryPoint version" caveat (e.g. `SafeAccountV0_3_0` is the *0.3.0 module* on **EP v0.7**, not v0.8)
- New "Paymaster Patterns" section: recommend `Erc7677Paymaster` (standard/portable); note `CandidePaymaster` sponsors in a single call on every EntryPoint incl. v0.9, and that commit/finalize is an optional latency optimization

## Tooling

- Add `npm run check` (`tsc --noEmit`) to type-check every example; passes across the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance clarifying Safe class/version mappings and expanded Paymaster Patterns with ERC-7677 and updated sponsorship behaviors.
* **New Features**
  * Added a complete, runnable migration example demonstrating upgrading a deployed Safe from EntryPoint v0.7 to v0.9 with a three-phase, sponsored end-to-end verification flow.
* **Chores**
  * Added a TypeScript type-check command to validate examples without emitting build output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/abstractionkit-examples/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->