### PR TITLE
docs(migrate-safe): note preflight for existing-account migrations

### DIFF
--- a/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
+++ b/migrate-safe-v07-to-v09/migrate-safe-v07-to-v09.ts
@@ -151,6 +151,14 @@ async function main(): Promise<void> {
     // ═════════════════════════════════════════════════════════════════════════
     // Phase 2 — Migrate to the v0.9 multi-chain module (validated by v0.7 module)
     // ═════════════════════════════════════════════════════════════════════════
+    // We deployed this Safe ourselves above, so we know it's a v0.7 Safe-4337
+    // account. When migrating an account you did NOT just deploy, preflight it
+    // first: confirm the old module is enabled AND is the current fallback handler
+    // (oldAccount.isModuleEnabled(...) + the fallback-handler read below) before
+    // building the batch — otherwise the migration UserOp fails validation on the
+    // v0.7 EntryPoint with an opaque AA23/AA24. (abstractionkit > 0.3.8's
+    // createMigrateToSafeMultiChainSigAccountV1MetaTransactions runs this preflight
+    // for you; pass { skipPreflight: true } to opt out.)
     console.log(`Phase 2: migrating to EntryPoint v0.9 (module ${NEW_MODULE})`)
 
     const migrationBatch = await createMigrateToV09MetaTransactions(oldAccount, nodeUrl)


### PR DESCRIPTION
## What

Adds a single clarifying comment at the Phase-2 boundary of `migrate-safe-v07-to-v09/`.

The example deploys the Safe itself in Phase 1, so it doesn't need a preflight before migrating. The comment makes that explicit and points out what you'd do differently when migrating an account you did **not** just deploy: verify the old module is enabled **and** is the current fallback handler first, otherwise the migration UserOp fails validation on the v0.7 EntryPoint with an opaque `AA23`/`AA24`.

It also notes that `abstractionkit > 0.3.8`'s `createMigrateToSafeMultiChainSigAccountV1MetaTransactions` runs this preflight automatically (opt out with `{ skipPreflight: true }`) — see the SDK PR that adds it.

## Notes

- Comment-only change; `npm run check` passes.
- No behavior change to the runnable flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced migration script documentation with clarifications on Safe deployment procedures and preflight requirements for module migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->