### PR TITLE
Add error-handling examples for UserOperation failures

### DIFF
--- a/error-handling/1-no-paymaster-underfunded.ts
+++ b/error-handling/1-no-paymaster-underfunded.ts
@@ -1,0 +1,47 @@
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import { SafeMultiChainSigAccountV1 as SafeAccount, MetaTransaction } from 'abstractionkit'
+import { classifyUserOpFailure } from './classifyUserOpFailure'
+
+/**
+ * Self-funded account with no ETH and no paymaster.
+ *
+ * The bundler rejects the op for not paying the prefund (AA21). The op is never
+ * mined, so there is no receipt: the failure arrives as a thrown error, either
+ * from gas estimation (createUserOperation) or from sendUserOperation.
+ */
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl } = loadEnv()
+    const { publicAddress, privateKey } = getOrCreateOwner()
+
+    const account = SafeAccount.initializeNewAccount([publicAddress])
+    console.log('Account (sender):', account.accountAddress)
+    console.log('This account is intentionally unfunded and uses no paymaster.\n')
+
+    const tx: MetaTransaction = { to: account.accountAddress, value: 0n, data: '0x' }
+
+    try {
+        const userOperation = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
+        userOperation.signature = account.signUserOperation(userOperation, [privateKey], chainId)
+
+        const response = await account.sendUserOperation(userOperation, bundlerUrl)
+        const receipt = await response.included()
+        if (receipt == null) {
+            console.log('Unexpected: receipt timed out (no classification).')
+        } else if (receipt.success) {
+            console.log('Unexpected: the op succeeded, so the account must have been funded.')
+        } else {
+            console.log('Included but reverted:', classifyUserOpFailure(receipt))
+        }
+    } catch (err) {
+        const failure = classifyUserOpFailure(err)
+        console.log('UserOperation failed before inclusion:')
+        console.log(failure)
+        console.log('\nSuggested wallet action:', failure.suggestedAction)
+        // In a wallet you would prompt the user to top up, then rebuild and resend:
+        //   const retryOp = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
+        //   retryOp.signature = account.signUserOperation(retryOp, [privateKey], chainId)
+        //   await account.sendUserOperation(retryOp, bundlerUrl)
+    }
+}
+
+main()

--- a/error-handling/2-token-insufficient.ts
+++ b/error-handling/2-token-insufficient.ts
@@ -1,0 +1,51 @@
+import { loadEnv, getOrCreateOwner, requireEnv } from '../utils/env'
+import { SafeMultiChainSigAccountV1 as SafeAccount, MetaTransaction, Erc7677Paymaster } from 'abstractionkit'
+import { classifyUserOpFailure } from './classifyUserOpFailure'
+
+/**
+ * Pay gas in an ERC-20 token, but the account holds none of it.
+ *
+ * The token-paymaster flow has nothing to charge, so it fails. Depending on the
+ * bundler this shows up as a thrown error at send time, or as a success:false
+ * receipt. The handler below covers both paths.
+ */
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl } = loadEnv()
+    const { publicAddress, privateKey } = getOrCreateOwner()
+    const tokenAddress = requireEnv('TOKEN_ADDRESS')
+
+    const account = SafeAccount.initializeNewAccount([publicAddress])
+    console.log('Account (sender):', account.accountAddress)
+    console.log('Paying gas in token', tokenAddress, 'but the account holds none.\n')
+
+    const tx: MetaTransaction = { to: account.accountAddress, value: 0n, data: '0x' }
+
+    try {
+        let userOperation = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
+        const paymaster = new Erc7677Paymaster(paymasterUrl)
+        // { token } triggers the token-gas flow: fetches a quote and prepends an approval.
+        const { userOperation: tokenOp } = await paymaster.createPaymasterUserOperation(
+            account, userOperation, bundlerUrl, { token: tokenAddress })
+        userOperation = tokenOp
+        userOperation.signature = account.signUserOperation(userOperation, [privateKey], chainId)
+
+        const response = await account.sendUserOperation(userOperation, bundlerUrl)
+        const receipt = await response.included()
+        if (receipt == null) {
+            console.log('Unexpected: receipt timed out (no classification).')
+        } else if (receipt.success) {
+            console.log('Unexpected: the op succeeded, so the account must hold the token.')
+        } else {
+            const failure = classifyUserOpFailure(receipt)
+            console.log('Included but reverted:', failure)
+            console.log('\nSuggested wallet action:', failure.suggestedAction)
+        }
+    } catch (err) {
+        const failure = classifyUserOpFailure(err)
+        console.log('Token-paymaster UserOperation failed before inclusion:')
+        console.log(failure)
+        console.log('\nSuggested wallet action:', failure.suggestedAction)
+    }
+}
+
+main()

--- a/error-handling/3-sponsor-denied.ts
+++ b/error-handling/3-sponsor-denied.ts
@@ -1,0 +1,44 @@
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import { SafeMultiChainSigAccountV1 as SafeAccount, MetaTransaction, Erc7677Paymaster } from 'abstractionkit'
+import { classifyUserOpFailure } from './classifyUserOpFailure'
+
+/**
+ * Ask for gas sponsorship and get denied.
+ *
+ * The denial happens while building the paymaster op: createPaymasterUserOperation
+ * calls the paymaster RPC, which returns an error, so it arrives as a thrown error.
+ *
+ * The public endpoint sponsors freely, so to get a denial reliably we point at a
+ * policy id that does not exist ('123'). With a real, valid policy the script
+ * reports that sponsorship was granted instead.
+ */
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl, paymasterUrl } = loadEnv()
+    const sponsorshipPolicyId = '123' // does not exist, so the sponsor rejects the op
+    const { publicAddress, privateKey } = getOrCreateOwner()
+
+    const account = SafeAccount.initializeNewAccount([publicAddress])
+    console.log('Account (sender):', account.accountAddress)
+    console.log('Requesting gas sponsorship with policy id:', sponsorshipPolicyId, '\n')
+
+    const tx: MetaTransaction = { to: account.accountAddress, value: 0n, data: '0x' }
+
+    try {
+        const userOperation = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
+        const paymaster = new Erc7677Paymaster(paymasterUrl)
+        const context = sponsorshipPolicyId ? { sponsorshipPolicyId } : {}
+        const { userOperation: sponsored } = await paymaster.createPaymasterUserOperation(
+            account, userOperation, bundlerUrl, context)
+        sponsored.signature = account.signUserOperation(sponsored, [privateKey], chainId)
+
+        console.log('Sponsorship was granted (no denial). To see a denial, use an invalid policy id.')
+    } catch (err) {
+        const failure = classifyUserOpFailure(err)
+        console.log('Sponsorship request failed:')
+        console.log(failure)
+        console.log('\nSuggested wallet action:', failure.suggestedAction)
+        // In a wallet you would fall back to self-funded or token gas here.
+    }
+}
+
+main()

--- a/error-handling/4-included-reverted.ts
+++ b/error-handling/4-included-reverted.ts
@@ -69,20 +69,18 @@ async function main(): Promise<void> {
         } else if (receipt.success) {
             console.log('Unexpected: the op succeeded, so the transfer did not revert.')
         } else {
+            // The classifier decodes the receipt to set its verdict, so its
+            // isRetriable and suggestedAction already reflect out-of-gas vs a hard
+            // revert. Call decodeUserOpRevertReason directly when you want the raw
+            // reason as well.
             const failure = classifyUserOpFailure(receipt)
             console.log('UserOperation was included but reverted:')
             console.log(failure)
 
-            // Why did it revert? Decode the EntryPoint's UserOperationRevertReason
-            // log straight from the receipt.
             const revert = decodeUserOpRevertReason(receipt)
-            console.log('\nRevert detail:', revert)
-            if (revert.outOfGas) {
-                console.log('Empty revert data, so most likely out of gas. Raise callGasLimit and')
-                console.log('resubmit as a new op (this one mined, so its nonce is already used).')
-            } else if (revert.errorMessage) {
-                console.log(`Reverted with reason "${revert.errorMessage}", a deliberate revert rather than gas.`)
-            }
+            if (revert.errorMessage) console.log('\nRevert reason:', revert.errorMessage)
+            else if (revert.outOfGas) console.log('\nNo revert data: most likely out of gas.')
+
             console.log('\nSuggested wallet action:', failure.suggestedAction)
             console.log('tx:', receipt.receipt.transactionHash)
         }

--- a/error-handling/4-included-reverted.ts
+++ b/error-handling/4-included-reverted.ts
@@ -1,0 +1,98 @@
+import { loadEnv, getOrCreateOwner, requireEnv } from '../utils/env'
+import {
+    SafeMultiChainSigAccountV1 as SafeAccount,
+    MetaTransaction,
+    getFunctionSelector,
+    createCallData,
+} from 'abstractionkit'
+import { classifyUserOpFailure } from './classifyUserOpFailure'
+import { decodeUserOpRevertReason } from './decodeUserOpRevertReason'
+
+/**
+ * Reach the execution stage and fail there (success:false).
+ *
+ * This is the only failure mode that actually gets mined. To reach it the op has
+ * to pass validation, which means gas has to be paid, so this demo is self-funded
+ * with no paymaster. A hosted paymaster will not help: it pre-screens the op and
+ * refuses to pay for one it can see will fail (Candide's paymaster enforces a
+ * minimum callGasLimit), so a sponsored op never reaches execution.
+ *
+ * Two things make the inner call fail on-chain rather than during estimation:
+ *   1. the call reverts: it transfers more tokens than the account owns.
+ *   2. skipGasEstimation is set, so createUserOperation does not simulate the call
+ *      (estimation would see the revert and throw before sending). We pass the gas
+ *      limits manually instead.
+ *
+ * The smart account (printed below as "sender") must hold a little testnet ETH to
+ * pay for gas. Fund that address first. Without ETH the bundler rejects with AA21
+ * and you get 'insufficient-account-funds' instead.
+ */
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl } = loadEnv()
+    const { publicAddress, privateKey } = getOrCreateOwner()
+    const tokenAddress = requireEnv('TOKEN_ADDRESS')
+
+    const account = SafeAccount.initializeNewAccount([publicAddress])
+    console.log('Account (sender):', account.accountAddress)
+    console.log('Self-funded (no paymaster). Fund this address with a little ETH first.\n')
+
+    // transfer(address,uint256) of far more than the account owns -> reverts on-chain.
+    const revertingTransfer = createCallData(
+        getFunctionSelector('transfer(address,uint256)'),
+        ['address', 'uint256'],
+        [publicAddress, (10n ** 30n).toString()],
+    )
+    const tx: MetaTransaction = { to: tokenAddress, value: 0n, data: revertingTransfer }
+
+    try {
+        const userOperation = await account.createUserOperation(
+            [tx],
+            nodeUrl,
+            bundlerUrl,
+            {
+                // Skip estimation so the reverting call is not simulated here.
+                // Gas prices are still fetched from the node automatically.
+                skipGasEstimation: true,
+                // Pass gas limits manually, generous enough to run until the revert.
+                callGasLimit: 200000n,
+                verificationGasLimit: 500000n,
+                preVerificationGas: 300000n,
+            },
+        )
+        userOperation.signature = account.signUserOperation(userOperation, [privateKey], chainId)
+
+        const response = await account.sendUserOperation(userOperation, bundlerUrl)
+        console.log('Sent, waiting for inclusion...')
+        const receipt = await response.included()
+        if (receipt == null) {
+            console.log('Receipt timed out (no classification).')
+        } else if (receipt.success) {
+            console.log('Unexpected: the op succeeded, so the transfer did not revert.')
+        } else {
+            const failure = classifyUserOpFailure(receipt)
+            console.log('UserOperation was included but reverted:')
+            console.log(failure)
+
+            // Why did it revert? Decode the EntryPoint's UserOperationRevertReason
+            // log straight from the receipt.
+            const revert = decodeUserOpRevertReason(receipt)
+            console.log('\nRevert detail:', revert)
+            if (revert.outOfGas) {
+                console.log('Empty revert data, so most likely out of gas. Raise callGasLimit and')
+                console.log('resubmit as a new op (this one mined, so its nonce is already used).')
+            } else if (revert.errorMessage) {
+                console.log(`Reverted with reason "${revert.errorMessage}", a deliberate revert rather than gas.`)
+            }
+            console.log('\nSuggested wallet action:', failure.suggestedAction)
+            console.log('tx:', receipt.receipt.transactionHash)
+        }
+    } catch (err) {
+        // If the account has no ETH this is AA21 instead. The classifier handles both.
+        const failure = classifyUserOpFailure(err)
+        console.log('UserOperation failed before inclusion:')
+        console.log(failure)
+        console.log('\nSuggested wallet action:', failure.suggestedAction)
+    }
+}
+
+main()

--- a/error-handling/5-gas-too-low-retry.ts
+++ b/error-handling/5-gas-too-low-retry.ts
@@ -23,8 +23,12 @@ async function main(): Promise<void> {
 
     const tx: MetaTransaction = { to: account.accountAddress, value: 0n, data: '0x' }
 
-    // Attempt 1: deliberately underpriced (1 wei gas price).
+    // Attempt 1: deliberately underpriced (1 wei gas price). Only retry if the
+    // failure classifies as retriable, whichever way it surfaces: a thrown error
+    // (the usual case for an underpriced op), a mined success:false receipt, or a
+    // null receipt (accepted but not bundled in time).
     console.log('Attempt 1: sending with maxFeePerGas = 1 wei (too low on purpose)...')
+    let retriable = false
     try {
         const op = await account.createUserOperation([tx], nodeUrl, bundlerUrl, {
             maxFeePerGas: 1n,
@@ -34,22 +38,31 @@ async function main(): Promise<void> {
         const resp = await account.sendUserOperation(op, bundlerUrl)
         const receipt = await resp.included()
         if (receipt?.success) {
-            console.log('Unexpected: the underpriced op was accepted; nothing to retry.')
+            console.log('  unexpected: the underpriced op was accepted; nothing to retry.')
             return
+        }
+        if (receipt) {
+            const failure = classifyUserOpFailure(receipt)
+            console.log(`  mined but failed (${failure.category}): ${failure.suggestedAction}`)
+            retriable = failure.isRetriable
+        } else {
+            console.log('  no receipt within the timeout; not retrying in this demo.')
         }
     } catch (err) {
         const failure = classifyUserOpFailure(err)
         console.log(`  rejected (${failure.category}): ${failure.suggestedAction}`)
-        if (!failure.isRetriable) {
-            console.log('  not retriable, stopping.')
-            return
-        }
+        retriable = failure.isRetriable
     }
 
-    // Attempt 2: it was retriable, so rebuild with current gas and resend.
+    if (!retriable) {
+        console.log('  not retriable, stopping.')
+        return
+    }
+
+    // Attempt 2: the failure was retriable, so rebuild with current gas and resend.
     // createUserOperation with no fee override refetches the current gas price and
     // re-estimates the limits, which is exactly the fix for a gas failure.
-    console.log('\nAttempt 2: retriable -> rebuilding with current gas and resending...')
+    console.log('\nAttempt 2: rebuilding with current gas and resending...')
     const retryOp = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
     retryOp.signature = account.signUserOperation(retryOp, [privateKey], chainId)
     const retryReceipt = await (await account.sendUserOperation(retryOp, bundlerUrl)).included()

--- a/error-handling/5-gas-too-low-retry.ts
+++ b/error-handling/5-gas-too-low-retry.ts
@@ -1,0 +1,63 @@
+import { loadEnv, getOrCreateOwner } from '../utils/env'
+import { SafeMultiChainSigAccountV1 as SafeAccount, MetaTransaction } from 'abstractionkit'
+import { classifyUserOpFailure } from './classifyUserOpFailure'
+
+/**
+ * The full loop: fail, classify, retry, succeed.
+ *
+ * Gas failures are the ones a wallet can usually retry on its own. The fix is to
+ * refetch the gas price (for fees) or re-estimate gas (for limits), without
+ * asking the user for anything. Here we deliberately underprice the op
+ * (maxFeePerGas = 1 wei), watch the bundler reject it, classify it as a retriable
+ * gas failure, then rebuild with current gas and resend, which succeeds.
+ *
+ * Self-funded: the smart account (sender) must hold a little testnet ETH to pay
+ * gas. Fund the address printed below before running.
+ */
+async function main(): Promise<void> {
+    const { chainId, bundlerUrl, nodeUrl } = loadEnv()
+    const { publicAddress, privateKey } = getOrCreateOwner()
+
+    const account = SafeAccount.initializeNewAccount([publicAddress])
+    console.log('Account (sender):', account.accountAddress, '\n')
+
+    const tx: MetaTransaction = { to: account.accountAddress, value: 0n, data: '0x' }
+
+    // Attempt 1: deliberately underpriced (1 wei gas price).
+    console.log('Attempt 1: sending with maxFeePerGas = 1 wei (too low on purpose)...')
+    try {
+        const op = await account.createUserOperation([tx], nodeUrl, bundlerUrl, {
+            maxFeePerGas: 1n,
+            maxPriorityFeePerGas: 1n,
+        })
+        op.signature = account.signUserOperation(op, [privateKey], chainId)
+        const resp = await account.sendUserOperation(op, bundlerUrl)
+        const receipt = await resp.included()
+        if (receipt?.success) {
+            console.log('Unexpected: the underpriced op was accepted; nothing to retry.')
+            return
+        }
+    } catch (err) {
+        const failure = classifyUserOpFailure(err)
+        console.log(`  rejected (${failure.category}): ${failure.suggestedAction}`)
+        if (!failure.isRetriable) {
+            console.log('  not retriable, stopping.')
+            return
+        }
+    }
+
+    // Attempt 2: it was retriable, so rebuild with current gas and resend.
+    // createUserOperation with no fee override refetches the current gas price and
+    // re-estimates the limits, which is exactly the fix for a gas failure.
+    console.log('\nAttempt 2: retriable -> rebuilding with current gas and resending...')
+    const retryOp = await account.createUserOperation([tx], nodeUrl, bundlerUrl)
+    retryOp.signature = account.signUserOperation(retryOp, [privateKey], chainId)
+    const retryReceipt = await (await account.sendUserOperation(retryOp, bundlerUrl)).included()
+    if (retryReceipt?.success) {
+        console.log('  success! tx:', retryReceipt.receipt.transactionHash)
+    } else {
+        console.log('  retry did not succeed:', retryReceipt)
+    }
+}
+
+main()

--- a/error-handling/README.md
+++ b/error-handling/README.md
@@ -1,0 +1,109 @@
+# Error handling
+
+When a UserOperation fails, a wallet needs to know why so it can react: top up the
+account, bump the gas, re-sign, or just tell the user it didn't go through.
+
+Two helpers do the work:
+
+- `classifyUserOpFailure(errorOrReceipt)` turns a failure into an actionable
+  verdict: `{ category, isRetriable, suggestedAction, aaCode?, reason }`.
+- `decodeUserOpRevertReason(receipt)` reads the on-chain revert reason out of a
+  mined-but-failed receipt.
+
+Each of the five scripts triggers one real failure on a live testnet and runs it
+through the classifier.
+
+## Where a UserOp fails
+
+A UserOp fails in one of two places, and they surface differently:
+
+- **Before it is mined (validation).** The bundler simulates the op and rejects
+  it, so there is no receipt. abstractionkit throws an `AbstractionKitError`, with
+  the bundler's reason (for example `AA21 didn't pay prefund`) on its `.cause`.
+- **After it is mined (execution).** The op was included but its inner call
+  reverted. You read it from the receipt: `success === false`.
+
+`classifyUserOpFailure` takes either shape and returns one verdict.
+
+## The examples
+
+```bash
+npx ts-node error-handling/<script>.ts
+```
+
+| # | Script | How gas is paid | What fails |
+|---|--------|-----------------|------------|
+| 1 | `1-no-paymaster-underfunded.ts` | Self-funded | Account has no ETH for the prefund (`AA21`) |
+| 2 | `2-token-insufficient.ts` | Token paymaster | Account holds none of the gas token |
+| 3 | `3-sponsor-denied.ts` | Sponsor paymaster | Sponsorship policy rejects the op |
+| 4 | `4-included-reverted.ts` | Self-funded | Op is mined, then the inner call reverts |
+| 5 | `5-gas-too-low-retry.ts` | Self-funded | Op is underpriced, then retried until it succeeds |
+
+Examples 1 to 3 cost nothing: leave `PUBLIC_ADDRESS` and `PRIVATE_KEY` out of
+`.env` and each run uses a throwaway zero-balance key, which is what triggers the
+failure. Example 3 forces a denial with a fake policy id, so it works out of the box.
+
+Examples 4 and 5 need the sender to hold a little testnet ETH, because reaching the
+execution stage means paying for gas yourself. Fund the address the script prints,
+then run it. Example 5 is the full loop: send underpriced, get a retriable
+`fees-too-low`, rebuild with current gas, resend, and succeed.
+
+## Calling it
+
+```ts
+try {
+  const response = await smartAccount.sendUserOperation(userOp, bundlerUrl)
+  const receipt = await response.included()
+
+  if (receipt && !receipt.success) {
+    // Mined, but the call reverted.
+    const failure = classifyUserOpFailure(receipt)   // { category: 'execution-reverted', ... }
+    const revert = decodeUserOpRevertReason(receipt) // { outOfGas, errorMessage, ... }
+  }
+} catch (err) {
+  // Rejected before inclusion.
+  const failure = classifyUserOpFailure(err)
+  if (failure.isRetriable) {
+    // bump or refetch gas and resend, following failure.suggestedAction
+  }
+}
+```
+
+## Categories
+
+`category` is one of:
+
+- `insufficient-account-funds`: the account can't cover the prefund (`AA21`/`AA51`)
+- `insufficient-token-funds`: token paymaster, not enough of the gas token
+- `sponsorship-denied`: the sponsor rejected the op
+- `fees-too-low`: gas price moved above what the op offered
+- `gas-limit-too-low`: a gas limit was set too low
+- `replacement-underpriced`: a speed-up did not bump the fee enough
+- `not-included`: the bundler accepted the op but never bundled it
+- `execution-reverted`: mined, but the inner call reverted
+- `nonce`, `signature`: stale nonce, bad signature
+- `unknown`: nothing matched, so read `reason`
+
+`isRetriable` says whether retrying can help; `suggestedAction` is a short line you
+can show the user.
+
+The classifier trusts codes before wording, because codes are stable and messages
+are not: the error `code` (`BUNDLER_ERROR` vs `PAYMASTER_ERROR`) and `cause.code`
+first, then the EntryPoint `AAxx` code, and only then keyword matching for the two
+cases no code pins down (token vs sponsor, both `-32003`; fee and gas-limit errors,
+`-32602`). Those keyword strings are tuned for Candide, so swap them for another
+provider.
+
+## Out-of-gas vs revert
+
+A `success: false` receipt does not say whether the call ran out of gas or reverted
+on purpose. `decodeUserOpRevertReason` reads the EntryPoint's
+`UserOperationRevertReason` log from the receipt you already have, with no extra RPC
+call, and returns the reason: a string for `revert("...")`, a panic code for
+`assert`, or empty data, which usually means out-of-gas (so it reports
+`outOfGas: true`). For certainty about out-of-gas, trace the bundle transaction with
+`debug_traceTransaction` or Tenderly, which is a one-off debugging step rather than
+a per-transaction call.
+
+One thing to remember: an execution revert already mined, so its nonce is spent.
+Retrying means a new op at the next nonce, not a same-nonce replacement.

--- a/error-handling/classifyUserOpFailure.ts
+++ b/error-handling/classifyUserOpFailure.ts
@@ -1,0 +1,141 @@
+import { UserOperationReceiptResult } from 'abstractionkit'
+
+export type UserOpFailure = {
+    category:
+        | 'insufficient-account-funds' // account can't pay the prefund (AA21/AA51)
+        | 'insufficient-token-funds'   // token paymaster: not enough gas token
+        | 'sponsorship-denied'         // sponsor rejected / paymaster validation failed
+        | 'fees-too-low'               // maxFeePerGas/maxPriorityFeePerGas below the bundler minimum
+        | 'gas-limit-too-low'          // a gas limit (pre-verification/call/verification) is too low
+        | 'replacement-underpriced'    // speed-up of a same-nonce op without enough fee bump
+        | 'not-included'               // accepted but not bundled in time (TIMEOUT); bump & resubmit
+        | 'execution-reverted'         // mined but the inner call reverted
+        | 'nonce'                      // stale/invalid nonce (AA25)
+        | 'signature'                  // invalid/expired signature (AA24)
+        | 'unknown'
+    isRetriable: boolean
+    /** Short line you can show the user. */
+    suggestedAction: string
+    /** The EntryPoint AAxx revert code, when present (e.g. 'AA21'). */
+    aaCode?: string
+    /** Raw bundler/receipt detail, for logs. */
+    reason: string
+}
+
+type Verdict = [UserOpFailure['category'], boolean, string]
+
+// EntryPoint FailedOp revert codes mapped to a verdict. These AAxx codes are
+// defined by the EntryPoint contract, not the bundler, so they stay the same
+// across compliant bundlers even when the wording after the code changes.
+const AA_CODES: Record<string, Verdict> = {
+    AA21: ['insufficient-account-funds', true, 'Top up the account with ETH and retry.'],
+    AA51: ['insufficient-account-funds', true, 'Prefund was below the actual gas cost. Top up the account and retry.'],
+    AA25: ['nonce', true, 'Stale nonce. Rebuild the UserOperation and retry.'],
+    AA24: ['signature', false, 'Invalid signature. Re-sign with the correct key.'],
+    AA31: ['sponsorship-denied', false, 'Paymaster deposit too low. Use a different paymaster or pay gas yourself.'],
+    AA33: ['sponsorship-denied', false, 'Paymaster validation failed. Check the paymaster or pay gas another way.'],
+    AA40: ['gas-limit-too-low', true, 'Verification used more gas than its limit. Re-estimate gas and retry.'],
+    AA41: ['gas-limit-too-low', true, 'verificationGasLimit was too low. Re-estimate gas and retry.'],
+    AA13: ['gas-limit-too-low', true, 'Account deployment ran out of gas, or the factory reverted. Re-estimate gas and retry.'],
+    AA23: ['gas-limit-too-low', true, 'Validation ran out of gas or was rejected. Re-estimate gas and retry; if it persists, re-sign the op.'],
+}
+
+// Gas fee and gas-limit failures carry no AAxx code. They arrive as -32602
+// "invalid fields" (or the paymaster's -32003) with the detail only in the
+// message, so match keywords. First rule wins, which is why "replacement ...
+// underpriced" is matched before the generic "underpriced".
+const KEYWORD_RULES: { keywords: string[]; verdict: Verdict }[] = [
+    { keywords: ['replacement'], verdict: ['replacement-underpriced', true, 'Replacement fee too low. Increase maxFeePerGas/maxPriorityFeePerGas (about 12%) and retry.'] },
+    { keywords: ['maxfeepergas', 'max fee per gas', 'maxpriorityfeepergas', 'max priority fee', 'fee too low', 'underpriced'], verdict: ['fees-too-low', true, 'Gas price rose above the offered fee. Refetch the gas price and retry.'] },
+    { keywords: ['preverificationgas', 'callgaslimit', 'verificationgaslimit', 'gas limit too low'], verdict: ['gas-limit-too-low', true, 'A gas limit was too low. Re-estimate gas and retry.'] },
+]
+
+const hasAny = (text: string, keywords: string[]): boolean => keywords.some((k) => text.includes(k))
+
+const REVERT_ACTION =
+    'The call reverts when executed, so the op would fail on-chain. Fix the transaction; retrying as-is will not help. See the reason field for the revert message.'
+
+/**
+ * Classify why a UserOperation failed.
+ *
+ * Pass either the thrown error (validation stage, never mined) or a
+ * UserOperationReceiptResult with success:false (execution stage).
+ *
+ * The classifier prefers codes over message text:
+ *  - abstractionkit's error `code` (BUNDLER_ERROR vs PAYMASTER_ERROR) and inner
+ *    `cause.code` (e.g. EXECUTION_REVERTED) give a robust coarse bucket.
+ *  - the EntryPoint `AAxx` revert code gives the precise reason, and stays the
+ *    same even if the bundler rewords the message.
+ * Keyword matching is only a fallback for cases no code pins down: token vs
+ * sponsor (both are the generic -32003) and the fee/gas-limit errors (generic
+ * -32602). Those keywords are best-effort and tuned for Candide.
+ */
+export function classifyUserOpFailure(input: unknown): UserOpFailure {
+    // Execution stage: a mined receipt that reverted.
+    if (typeof input === 'object' && input !== null && 'success' in input) {
+        const receipt = input as NonNullable<UserOperationReceiptResult>
+        if (!receipt.success) {
+            return toFailure(['execution-reverted', false,
+                'Included on-chain but the call reverted. Use decodeUserOpRevertReason(receipt) to read why.'],
+                `success=false tx=${receipt.receipt.transactionHash}`)
+        }
+    }
+
+    // A thrown AbstractionKitError (or anything else).
+    const err = input as { code?: string; cause?: { code?: unknown; message?: string }; message?: string } | undefined
+    const reason = err?.cause?.message ?? err?.message ?? String(input)
+    const lower = reason.toLowerCase()
+
+    // Not a failure but a TIMEOUT: the bundler accepted the op (it has a hash) but
+    // did not bundle it in time, so included() throws TIMEOUT "can't find
+    // useroperation". The op is stuck (often on low fees) or was dropped. Replace
+    // it the way you speed up a stuck Ethereum tx: same nonce, higher fees, re-sign.
+    if (err?.code === 'TIMEOUT' || lower.includes("can't find useroperation") || lower.includes('cannot find useroperation')) {
+        return toFailure(['not-included', true,
+            'The bundler accepted the op but did not include it in time. Keep the same nonce, bump maxFeePerGas and maxPriorityFeePerGas (about 12%), re-sign, and resubmit.'], reason)
+    }
+
+    // SDK cause.code first. It is the most reliable signal, and it disambiguates a
+    // code the AAxx string alone cannot: EXECUTION_REVERTED is the pre-flight twin
+    // of the success:false receipt above (for example a transfer of more than the
+    // balance). Checking it before the AAxx table is what lets AA23 ("reverted or
+    // OOG") resolve to execution-reverted here, or to gas-limit-too-low if it falls
+    // through to the table as a validation out-of-gas.
+    if (err?.cause?.code === 'EXECUTION_REVERTED') {
+        return toFailure(['execution-reverted', false, REVERT_ACTION], reason)
+    }
+    if (err?.cause?.code === 'INVALID_SIGNATURE') {
+        return toFailure(['signature', false, 'Invalid signature. Re-sign with the correct key.'], reason)
+    }
+    // Some providers report an execution revert in the message rather than a code,
+    // e.g. a token paymaster's "validator: callData reverts" (-32003). Same meaning
+    // as EXECUTION_REVERTED. Check it before the paymaster bucket so it is not
+    // mistaken for a sponsorship denial.
+    if (hasAny(lower, ['calldata revert', 'call data revert', 'execution revert'])) {
+        return toFailure(['execution-reverted', false, REVERT_ACTION], reason)
+    }
+
+    // EntryPoint AAxx revert code.
+    for (const code of Object.keys(AA_CODES)) {
+        if (lower.includes(code.toLowerCase())) return toFailure(AA_CODES[code], reason, code)
+    }
+
+    // Gas fee and gas-limit failures, by keyword. Can come from the bundler or the paymaster.
+    for (const rule of KEYWORD_RULES) {
+        if (hasAny(lower, rule.keywords)) return toFailure(rule.verdict, reason)
+    }
+
+    // Paymaster failures: token vs sponsor (both share the generic -32003).
+    if (err?.code === 'PAYMASTER_ERROR') {
+        if (hasAny(lower, ['token', 'allowance', 'balance'])) {
+            return toFailure(['insufficient-token-funds', true, 'Fund the account with more of the gas token and retry.'], reason)
+        }
+        return toFailure(['sponsorship-denied', false, 'Sponsorship was denied. Check the policy or pay gas another way.'], reason)
+    }
+
+    return toFailure(['unknown', false, 'Unrecognized failure. Inspect the reason field.'], reason)
+}
+
+function toFailure([category, isRetriable, suggestedAction]: Verdict, reason: string, aaCode?: string): UserOpFailure {
+    return { category, isRetriable, suggestedAction, aaCode, reason }
+}

--- a/error-handling/classifyUserOpFailure.ts
+++ b/error-handling/classifyUserOpFailure.ts
@@ -1,4 +1,5 @@
 import { UserOperationReceiptResult } from 'abstractionkit'
+import { decodeUserOpRevertReason } from './decodeUserOpRevertReason'
 
 export type UserOpFailure = {
     category:
@@ -36,7 +37,7 @@ const AA_CODES: Record<string, Verdict> = {
     AA33: ['sponsorship-denied', false, 'Paymaster validation failed. Check the paymaster or pay gas another way.'],
     AA40: ['gas-limit-too-low', true, 'Verification used more gas than its limit. Re-estimate gas and retry.'],
     AA41: ['gas-limit-too-low', true, 'verificationGasLimit was too low. Re-estimate gas and retry.'],
-    AA13: ['gas-limit-too-low', true, 'Account deployment ran out of gas, or the factory reverted. Re-estimate gas and retry.'],
+    AA13: ['gas-limit-too-low', true, 'Account deployment failed (factory reverted or ran out of gas). Re-estimate gas and retry; if it persists, the factory rejected the inputs.'],
     AA23: ['gas-limit-too-low', true, 'Validation ran out of gas or was rejected. Re-estimate gas and retry; if it persists, re-sign the op.'],
 }
 
@@ -71,13 +72,23 @@ const REVERT_ACTION =
  * -32602). Those keywords are best-effort and tuned for Candide.
  */
 export function classifyUserOpFailure(input: unknown): UserOpFailure {
-    // Execution stage: a mined receipt that reverted.
+    // Execution stage: a mined receipt that reverted. Decode the revert reason
+    // (no extra RPC, the logs are in the receipt) so the verdict can tell a
+    // retriable out-of-gas from a hard revert. Out-of-gas is a heuristic here
+    // (empty revert data is usually OOG, sometimes a bare revert()), and the op
+    // already mined, so the retry is a NEW op at the next nonce, not a resend.
     if (typeof input === 'object' && input !== null && 'success' in input) {
         const receipt = input as NonNullable<UserOperationReceiptResult>
         if (!receipt.success) {
+            const reason = `success=false tx=${receipt.receipt.transactionHash}`
+            const revert = decodeUserOpRevertReason(receipt)
+            if (revert.outOfGas) {
+                return toFailure(['execution-reverted', true,
+                    'Ran out of gas during execution. Raise callGasLimit and send a new op (this one mined, so its nonce is used).'], reason)
+            }
+            const detail = revert.errorMessage ? `: ${revert.errorMessage}` : ''
             return toFailure(['execution-reverted', false,
-                'Included on-chain but the call reverted. Use decodeUserOpRevertReason(receipt) to read why.'],
-                `success=false tx=${receipt.receipt.transactionHash}`)
+                `Included on-chain but the call reverted${detail}. Fix the call; retrying as-is will not help.`], reason)
         }
     }
 

--- a/error-handling/decodeUserOpRevertReason.ts
+++ b/error-handling/decodeUserOpRevertReason.ts
@@ -47,7 +47,18 @@ function gatherLogs(receipt: NonNullable<UserOperationReceiptResult>): any[] {
 export function decodeUserOpRevertReason(receipt: NonNullable<UserOperationReceiptResult>): UserOpRevert {
     if (receipt.success) return { reverted: false, outOfGas: false, rawRevertReason: '0x' }
 
-    const log = gatherLogs(receipt).find((l) => l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC)
+    // UserOperationRevertReason is indexed by userOpHash (topic[1]). A bundle can
+    // contain several reverted ops, so match this op's hash as well as the event
+    // topic; otherwise we could pick up another op's revert reason from the bundle
+    // logs. The guard keeps it working for a receipt without the top-level hash.
+    // (Inner-call logs of this op do not carry the hash and would need locating by
+    // logIndex range, which is out of scope here.)
+    const userOpHash = (receipt as { userOpHash?: string }).userOpHash?.toLowerCase()
+    const log = gatherLogs(receipt).find(
+        (l) =>
+            l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC &&
+            (userOpHash == null || l?.topics?.[1]?.toLowerCase() === userOpHash),
+    )
     if (!log) return { reverted: true, outOfGas: false, rawRevertReason: '0x' }
 
     // data = abi.encode(uint256 nonce, bytes revertReason)

--- a/error-handling/decodeUserOpRevertReason.ts
+++ b/error-handling/decodeUserOpRevertReason.ts
@@ -1,0 +1,72 @@
+import { UserOperationReceiptResult } from 'abstractionkit'
+import { decodeAbiParameters } from 'viem'
+
+export type UserOpRevert = {
+    /** success === false on the receipt. */
+    reverted: boolean
+    /** The inner call left no revert data. Usually out-of-gas, though a bare
+     *  revert()/assert or a call to a non-contract also produce empty data. */
+    outOfGas: boolean
+    /** Decoded Error("...") string, when the call reverted with a reason. */
+    errorMessage?: string
+    /** Decoded Panic(uint256) code (0x11 overflow, 0x12 div-by-zero, ...). */
+    panicCode?: number
+    /** The raw revertReason bytes (for custom errors / further decoding). */
+    rawRevertReason: string
+}
+
+// EntryPoint event: UserOperationRevertReason(bytes32 userOpHash, address sender, uint256 nonce, bytes revertReason)
+// topic0 verified live against the v0.9 EntryPoint (0x4337...D009) on Arbitrum, and is the same for v0.6/0.7/0.8.
+const REVERT_REASON_TOPIC = '0x1c4fada7374c0a9ee8841fc38afe82932dc0f8e69012e927f061a8bae611a201'
+const ERROR_SELECTOR = '0x08c379a0' // Error(string)
+const PANIC_SELECTOR = '0x4e487b71' // Panic(uint256)
+
+/** abstractionkit stores receipt logs as JSON strings; gather them as objects. */
+function gatherLogs(receipt: NonNullable<UserOperationReceiptResult>): any[] {
+    const out: any[] = []
+    const sources: unknown[] = [receipt.logs, receipt.receipt?.logs]
+    for (const src of sources) {
+        if (typeof src === 'string') { try { out.push(...JSON.parse(src)) } catch { /* ignore */ } }
+        else if (Array.isArray(src)) out.push(...src)
+    }
+    return out
+}
+
+/**
+ * Work out why a UserOperation reverted on-chain, using only the receipt the
+ * wallet already has. No extra RPC call, no debug_traceTransaction.
+ *
+ * It reads the EntryPoint's `UserOperationRevertReason` event from the logs and
+ * decodes the revert data: a reason string (Error), a panic code (Panic), empty
+ * data (usually out-of-gas), or raw bytes (a custom error).
+ *
+ * To be certain about out-of-gas rather than a bare revert(), trace the bundle
+ * transaction with debug_traceTransaction or Tenderly. That is a one-off
+ * debugging step, not something a wallet runs on every transaction.
+ */
+export function decodeUserOpRevertReason(receipt: NonNullable<UserOperationReceiptResult>): UserOpRevert {
+    if (receipt.success) return { reverted: false, outOfGas: false, rawRevertReason: '0x' }
+
+    const log = gatherLogs(receipt).find((l) => l?.topics?.[0]?.toLowerCase() === REVERT_REASON_TOPIC)
+    if (!log) return { reverted: true, outOfGas: false, rawRevertReason: '0x' }
+
+    // data = abi.encode(uint256 nonce, bytes revertReason)
+    const decode = (params: { type: string }[], data: string): unknown[] =>
+        decodeAbiParameters(params as any, data as `0x${string}`) as unknown as unknown[]
+
+    const revertReasonRaw = decode([{ type: 'uint256' }, { type: 'bytes' }], log.data)[1] as string
+    const revertReason = revertReasonRaw.toLowerCase()
+
+    if (revertReason === '0x' || revertReason === '') {
+        return { reverted: true, outOfGas: true, rawRevertReason: '0x' }
+    }
+    if (revertReason.startsWith(ERROR_SELECTOR)) {
+        const msg = decode([{ type: 'string' }], '0x' + revertReason.slice(10))[0] as string
+        return { reverted: true, outOfGas: false, errorMessage: msg, rawRevertReason: revertReasonRaw }
+    }
+    if (revertReason.startsWith(PANIC_SELECTOR)) {
+        const code = decode([{ type: 'uint256' }], '0x' + revertReason.slice(10))[0] as bigint
+        return { reverted: true, outOfGas: false, panicCode: Number(code), rawRevertReason: revertReasonRaw }
+    }
+    return { reverted: true, outOfGas: false, rawRevertReason: revertReasonRaw as string }
+}


### PR DESCRIPTION
Adds an `error-handling/` folder showing how to tell why a UserOperation failed and what to do about it.

- `classifyUserOpFailure(errorOrReceipt)`: turns a thrown error or a `success:false` receipt into an actionable verdict (`category`, `isRetriable`, `suggestedAction`, `reason`), preferring stable codes over message text.
- `decodeUserOpRevertReason(receipt)`: reads the EntryPoint `UserOperationRevertReason` log from the receipt to tell out-of-gas from a plain revert, no extra RPC.
- Five runnable demos: underfunded (AA21), token-paymaster insufficient, sponsor denied, included-but-reverted, and an underpriced-then-retried-to-success loop.

All demos were verified live on Arbitrum Sepolia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added robust error-handling tools for Smart Account user-operations: a failure classifier and a revert-reason decoder.
  * Added example scripts demonstrating failure scenarios (no funding, token shortfall, sponsor denial, included revert, gas-too-low retry) that classify failures and print suggested wallet actions.

* **Documentation**
  * Added an error-handling guide explaining failure modes, classifier output, revert decoding, and recovery guidance with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->