### PR TITLE
Make insufficient-token-balance paymaster error discoverable in error-handling example

### DIFF
--- a/error-handling/2-token-insufficient.ts
+++ b/error-handling/2-token-insufficient.ts
@@ -3,11 +3,20 @@ import { SafeMultiChainSigAccountV1 as SafeAccount, MetaTransaction, Erc7677Paym
 import { classifyUserOpFailure } from './classifyUserOpFailure'
 
 /**
- * Pay gas in an ERC-20 token, but the account holds none of it.
+ * Pay gas in an ERC-20 token, but the account's token balance is below what the
+ * paymaster needs. This covers both "holds none" and "holds some, but not
+ * enough" — the failure is identical either way.
  *
- * The token-paymaster flow has nothing to charge, so it fails. Depending on the
- * bundler this shows up as a thrown error at send time, or as a success:false
- * receipt. The handler below covers both paths.
+ * When the required amount exceeds the balance, the Candide paymaster rejects
+ * the op during the paymaster call with:
+ *
+ *     validator: token balance lower than the required 0x5be0f allowance
+ *
+ * abstractionkit surfaces that as an AbstractionKitError with code
+ * PAYMASTER_ERROR (the validator message on err.cause.message), which
+ * classifyUserOpFailure maps to category 'insufficient-token-funds'. Depending
+ * on the bundler an underfunded op can instead slip through to send time or to a
+ * success:false receipt, so the handler below covers both paths.
  */
 async function main(): Promise<void> {
     const { chainId, bundlerUrl, nodeUrl, paymasterUrl } = loadEnv()

--- a/error-handling/README.md
+++ b/error-handling/README.md
@@ -34,7 +34,7 @@ npx ts-node error-handling/<script>.ts
 | # | Script | How gas is paid | What fails |
 |---|--------|-----------------|------------|
 | 1 | `1-no-paymaster-underfunded.ts` | Self-funded | Account has no ETH for the prefund (`AA21`) |
-| 2 | `2-token-insufficient.ts` | Token paymaster | Account holds none of the gas token |
+| 2 | `2-token-insufficient.ts` | Token paymaster | Account's gas-token balance is below the required amount (`validator: token balance lower than the required … allowance`) — none or just not enough |
 | 3 | `3-sponsor-denied.ts` | Sponsor paymaster | Sponsorship policy rejects the op |
 | 4 | `4-included-reverted.ts` | Self-funded | Op is mined, then the inner call reverts |
 | 5 | `5-gas-too-low-retry.ts` | Self-funded | Op is underpriced, then retried until it succeeds |


### PR DESCRIPTION
## What

Closes the discoverability gap for the token-paymaster "not enough balance" failure in the error-handling examples. **No logic change** — `classifyUserOpFailure` already mapped this error to `insufficient-token-funds`; this just makes the example and docs match the error users actually hit.

## Changes

- `error-handling/2-token-insufficient.ts` — reworded the docstring to cover "holds some but not enough" (not just zero balance), and quote the literal Candide paymaster error:
  `validator: token balance lower than the required … allowance`
  with the `PAYMASTER_ERROR` → `insufficient-token-funds` mapping.
- `error-handling/README.md` — broadened the example #2 table row and embedded the literal error string so it's greppable.

## Verification

- `npm run check` passes clean.

> Note: the abstractionkit 0.4.0 upgrade is already on `main`, so this PR contains only the two doc changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced error-handling documentation with clearer examples covering token insufficient scenarios, including cases where an account holds no tokens or insufficient tokens, along with details on error patterns, categorization behavior, and bundler failure outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->