### PR TITLE
Fix nested-safe example signing on the multichain account

### DIFF
--- a/nested-safe-accounts/nested-safe-accounts.ts
+++ b/nested-safe-accounts/nested-safe-accounts.ts
@@ -141,12 +141,22 @@ async function main(): Promise<void> {
         mainAccount, mainAccountUserOperation, bundlerUrl, sponsorshipPolicyId ? { sponsorshipPolicyId } : undefined)
     mainAccountUserOperation = paymasterUserOperation1;
 
-    mainAccountUserOperation.signature = SafeAccount.formatSignaturesToUseroperationSignature(
+    //use the multichain formatter (not the parent formatSignaturesToUseroperationSignature):
+    //the multichain module expects the signature prefixed with the merkle tree depth
+    //(0x00 for a single useroperation) plus the validity window, and hashed against
+    //the multichain module address. The parent helper emits neither, so the account
+    //rejects the signature.
+    mainAccountUserOperation.signature = SafeAccount.formatSignaturesToUseroperationsSignatures(
+        [{ userOperation: mainAccountUserOperation, chainId }],
         [subAccount1SignerSignaturePair, subAccount2SignerSignaturePair],
-    )
+    )[0]
     /***********************************/
     //create approveHash metaTransaction
-    const userOperationEip712Hash = SafeAccount.getUserOperationEip712Hash_V9(
+    //use the multichain-class override (not the parent getUserOperationEip712Hash_V9),
+    //it defaults safe4337ModuleAddress to the multichain module the account actually
+    //verifies against. The parent helper defaults to a different module, so the
+    //approved hash would not match and the bundler rejects with INVALID_SIGNATURE.
+    const userOperationEip712Hash = SafeAccount.getUserOperationEip712Hash(
         mainAccountUserOperation,
         chainId,
     );


### PR DESCRIPTION
Verified live on Sepolia: the main account userOp failed with bundler INVALID_SIGNATURE (-32507) before, and is included with success: true after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mint NFT transaction signing for multichain operations.
  * Updated transaction hash verification to ensure approved signatures match the account module’s validation method.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->